### PR TITLE
claude/investigate-ci-contributor-access-F0QXw

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -119,7 +123,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Comment PR with coverage
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Fork PRs get a read-only GITHUB_TOKEN, so the actions/github-script
step that posts a coverage comment fails with 403. Gate it on
head.repo.full_name == github.repository so it only runs for
same-repo PRs.

https://claude.ai/code/session_01JGQh1WLaEG3XqccrPKpqSx