### PR TITLE
fix(ci): add workflow permissions for PR coverage comments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
The "Comment PR with coverage" step failed with "Resource not accessible by integration" because the default GITHUB_TOKEN lacked write access to pull requests. Add explicit workflow-level permissions granting contents:read and pull-requests:write so the coverage comment step can post to PRs without requiring repo-wide elevated token settings.