### PR TITLE
doc: rewrite README for current API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
-> This is a very early proof of concept of the Sendspin protocol. The protocol will likely change. This does work today (10/26), but may not work tomorrow.
-
-> [!WARNING]
-> **Incomplete implementation.** This SDK is missing the [Sendspin time filter](https://github.com/Sendspin/time-filter) — a Kalman filter required for accurate clock synchronization. The current implementation uses a fixed-gain estimator that does not track drift or adapt to measurement quality, which will result in poor synchronization accuracy. This SDK should not be used for synchronized audio playback until a proper time filter is implemented.
-
 # SendspinKit
 
-A Swift client library for the [Sendspin Protocol](https://github.com/Sendspin/spec) - enabling synchronized multi-room audio playback on Apple platforms.
+A Swift client library for the [Sendspin Protocol](https://github.com/Sendspin/spec) — enabling synchronized multi-room audio playback on Apple platforms.
 
 ## Features
 
-- 🎵 **Player Role**: Synchronized audio playback with microsecond precision
-- 🎛️ **Controller Role**: Control playback across device groups
-- 📝 **Metadata Role**: Display track information and progress
-- 🔍 **Auto-discovery**: mDNS/Bonjour server discovery
-- 🎵 **Multi-codec**: PCM, Opus, and FLAC support for flexible streaming
-- ⏱️ **Clock Sync**: NTP-style time synchronization
+- **Player Role** — Synchronized audio playback with microsecond-precision clock sync
+- **Controller Role** — Play, pause, skip, volume, shuffle, repeat across device groups
+- **Metadata Role** — Track info, artwork URLs, and playback progress
+- **Artwork Role** — Album art delivery with format and resolution negotiation
+- **Auto-discovery** — mDNS/Bonjour server discovery with continuous or one-shot modes
+- **Multi-codec** — PCM, Opus, and FLAC support with seamless mid-stream format switching
+- **Clock Sync** — Kalman filter time synchronization with drift tracking and adaptive forgetting
+- **Hardware & Software Volume** — Perceptual gain curve with per-device or per-queue control
 
 ## Requirements
 
@@ -27,7 +24,7 @@ A Swift client library for the [Sendspin Protocol](https://github.com/Sendspin/s
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/YOUR_ORG/SendspinKit.git", from: "0.1.0")
+    .package(url: "https://github.com/Sendspin/SendspinKit.git", from: "1.0.0")
 ]
 ```
 
@@ -36,74 +33,95 @@ dependencies: [
 ```swift
 import SendspinKit
 
-// Create client with player role
-let client = SendspinClient(
+// Create a player client
+let client = try SendspinClient(
     clientId: "my-device",
     name: "Living Room Speaker",
-    roles: [.player],
-    playerConfig: PlayerConfiguration(
-        bufferCapacity: 1_048_576, // 1MB
+    roles: [.playerV1],
+    playerConfig: try PlayerConfiguration(
+        bufferCapacity: 1_048_576,
         supportedFormats: [
-            AudioFormatSpec(codec: .pcm, channels: 2, sampleRate: 48000, bitDepth: 16),
-            AudioFormatSpec(codec: .opus, channels: 2, sampleRate: 48000, bitDepth: 16),
-            AudioFormatSpec(codec: .flac, channels: 2, sampleRate: 48000, bitDepth: 16),
+            try AudioFormatSpec(codec: .pcm, channels: 2, sampleRate: 48_000, bitDepth: 16),
+            try AudioFormatSpec(codec: .flac, channels: 2, sampleRate: 48_000, bitDepth: 16),
         ]
     )
 )
 
-// Discover servers
-let discovery = SendspinDiscovery()
-await discovery.startDiscovery()
+// Discover and connect to the first server found
+let servers = try await SendspinClient.discoverServers(timeout: .seconds(5))
+if let server = servers.first {
+    try await client.connect(to: server.url)
+}
 
-for await server in discovery.discoveredServers {
-    if let url = await discovery.resolveServer(server) {
-        try await client.connect(to: url)
+// React to events
+for await event in client.events {
+    switch event {
+    case .streamStarted(let format):
+        print("Playing \(format.codec) at \(format.sampleRate)Hz")
+    case .metadataReceived(let metadata):
+        print("Now playing: \(metadata.title ?? "Unknown")")
+    case .disconnected(let reason):
+        print("Disconnected: \(reason)")
+    default:
         break
     }
 }
+```
 
-// Client automatically handles:
-// - WebSocket connection
-// - Clock synchronization
-// - Audio stream reception
-// - Synchronized playback
+### Controller + Metadata
+
+```swift
+let controller = try SendspinClient(
+    clientId: "my-remote",
+    name: "Kitchen Display",
+    roles: [.controllerV1, .metadataV1]
+)
+
+try await controller.connect(to: serverURL)
+
+// Control playback
+try await controller.play()
+try await controller.next()
+try await controller.setGroupVolume(75)
+try await controller.setShuffle(true)
+```
+
+### Continuous Discovery
+
+```swift
+let discovery = try await SendspinClient.discoverServers()
+for await servers in discovery.servers {
+    print("Found \(servers.count) server(s):")
+    for server in servers {
+        print("  \(server.name) at \(server.url)")
+    }
+}
 ```
 
 ## Codec Support
 
-SendspinKit supports multiple audio codecs for high-quality streaming:
+- **PCM** — Uncompressed audio up to 192kHz/32-bit (zero-copy passthrough)
+- **Opus** — Low-latency lossy compression (8-48kHz, optimized for real-time)
+- **FLAC** — Lossless compression with hi-res support (up to 192kHz/24-bit)
 
-- **PCM** - Uncompressed audio up to 192kHz 32-bit (zero-copy passthrough)
-- **Opus** - Low-latency lossy compression (8-48kHz, optimized for real-time)
-- **FLAC** - Lossless compression with hi-res support (up to 192kHz 24-bit)
-
-All codecs output normalized int32 PCM for consistent pipeline processing. See [docs/CODEC_SUPPORT.md](docs/CODEC_SUPPORT.md) for detailed codec documentation, performance characteristics, and implementation guide.
+All codecs output normalized int32 PCM for consistent pipeline processing.
 
 ## Audio Synchronization
 
-SendspinKit uses timestamp-based audio scheduling to ensure precise synchronization:
+SendspinKit uses a Kalman filter for clock synchronization and timestamp-based audio scheduling:
 
-- **AudioScheduler**: Maintains priority queue of audio chunks sorted by playback time
-- **Clock Sync**: Compensates for clock drift using Kalman filter approach
-- **Playback Window**: ±50ms tolerance for network jitter
-- **Late Chunk Handling**: Automatically drops chunks >50ms late to maintain sync
-- **AsyncStream Pipeline**: Non-blocking chunk output for smooth playback
+- **Clock Sync** — Full 2D covariance Kalman filter with adaptive forgetting, drift SNR gating, and RTT floor
+- **AudioScheduler** — Priority queue of audio chunks sorted by playback time
+- **Playback Window** — Configurable tolerance for network jitter (default +/-50ms)
+- **Sync Correction** — Frame-level drop/insert to maintain alignment without audible glitches
 
-The scheduler converts server timestamps to local playback times and ensures chunks play at their intended moment, not when they arrive from the network.
+## Documentation
 
-## Testing
+API documentation is available via DocC. Build it locally with:
 
-- **Swift Bring-Up Guide**: See [docs/SWIFT_BRINGUP.md](docs/SWIFT_BRINGUP.md) for codec negotiation, scheduler architecture, clock sync details, and the 5-minute PCM stream test procedure.
-- **Manual Testing**: See [docs/TESTING.md](docs/TESTING.md) for manual testing procedures and validation checklist.
-
-## TODO
-
-- [ ] Verify hi-res audio (192kHz/24-bit) end-to-end with real hardware
-- [ ] Test compatibility with other Sendspin Protocol server implementations
-- [ ] Update implementation as Sendspin Protocol spec solidifies
-- [ ] Comprehensive audit and bug fixes
-
-See [GitHub Issues](https://github.com/harperreed/SendspinKit/issues) for detailed tracking and discussion.
+```bash
+swift package generate-documentation
+```
 
 ## License
 


### PR DESCRIPTION
Remove stale "proof of concept" and "incomplete implementation" warnings — the time filter, artwork role, controller role, and discovery are all implemented. Update the Quick Start to use the current throwing initializers and public API (discoverServers, events stream, typed controller methods). Add controller+metadata and continuous discovery examples. Remove TODOs that are done and references to docs that no longer exist.