### PR TITLE
sync: refresh Kalman filter math from C++ reference, add diagnostics

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -617,14 +617,20 @@ public final class SendspinClient {
                 let currentStats = await audioScheduler.stats
                 guard currentStats.received > 0 else { continue }
 
+                // Atomic snapshot of clock-sync state — single actor hop covers
+                // offset, RTT, and the Kalman convergence diagnostics.
+                guard let syncSnap = await clockSync.diagnosticSnapshot() else { continue }
+
                 let framesScheduled = currentStats.received - lastTelemetryStats.received
                 let framesPlayed = currentStats.played - lastTelemetryStats.played
                 let framesDroppedLate = currentStats.droppedLate - lastTelemetryStats.droppedLate
 
-                let offset = await clockSync.currentOffset
-                let rtt = await clockSync.latestAcceptedRtt
-                let clockOffsetMs = Double(offset) / 1_000.0
-                let rttMs = Double(rtt) / 1_000.0
+                let clockOffsetMs = Double(syncSnap.offset) / 1_000.0
+                let rttMs = Double(syncSnap.rtt) / 1_000.0
+                let estErrUs = Int64(syncSnap.estimatedError.rounded())
+                // Drift is dimensionless (μs of offset per μs of time); ppm is the
+                // human-readable form for clock-drift rates.
+                let driftPpm = syncSnap.drift * 1_000_000.0
 
                 // Read sync error computed by the audio callback (precise, no actor jitter)
                 let tSnap = await audioPlayer.telemetrySnapshot
@@ -642,6 +648,9 @@ public final class SendspinClient {
                     + " buf=\(String(format: "%.1f", currentStats.bufferFillMs))ms"
                     + " offset=\(String(format: "%.2f", clockOffsetMs))ms"
                     + " rtt=\(String(format: "%.2f", rttMs))ms"
+                    + " est=\(estErrUs)us"
+                    + " drift=\(String(format: "%.2f", driftPpm))ppm"
+                    + " samples=\(syncSnap.sampleCount)"
                     + " queue=\(currentStats.queueSize)"
                     + " sync=\(syncErrorUs)us"
                     + " correcting=\(correcting)"

--- a/Sources/SendspinKit/Synchronization/SendspinTimeFilter.swift
+++ b/Sources/SendspinKit/Synchronization/SendspinTimeFilter.swift
@@ -5,22 +5,22 @@ import Foundation
 
 /// Two-dimensional Kalman filter tracking clock offset and drift rate.
 ///
-/// This is a faithful port of the C++ reference implementation with:
+/// Features:
 /// - Full 2x2 covariance matrix propagation
 /// - Per-sample measurement noise derived from RTT
 /// - Adaptive forgetting factor for changing network conditions
 /// - Drift significance SNR gate (only applies drift when statistically meaningful)
-/// - RTT floor of 1μs to prevent zero-variance NaN on localhost (from Rust port)
-///
-/// Defaults match the reference project's README recommendations
-/// (`time-filter/README.md`, "Recommended Values") — notably
-/// `driftProcessStdDev = 0.0`. A nonzero drift process noise with typical
-/// sync intervals (hundreds of ms) inflates `driftCovariance` fast enough
-/// that the prediction step's `driftCov · dt²` term dominates `R`,
-/// pinning `offsetCovariance` at `measurementVariance` every step — i.e.
-/// the filter never learns from more than one sample.
+/// - `maxError` scaling (`maxErrorScale = 0.5` by default): `maxError` is a
+///   worst-case bound (RTT/2), not a 1σ estimate, so using it unscaled
+///   over-inflates the measurement variance and slows convergence.
+/// - RTT floor of 1μs to prevent zero-variance NaN on localhost.
 ///
 /// Units: all timestamps in microseconds (Int64), offset/drift in microseconds (Double).
+/// `processStdDev` is a diffusion coefficient with units μs/√μs; offset
+/// variance grows by `processStdDev² · dt` per μs of elapsed time.
+/// `driftProcessStdDev` is a diffusion coefficient with units 1/√μs; drift is
+/// dimensionless (μs of offset per μs of time), so its variance also grows
+/// by `driftProcessStdDev² · dt` per μs of elapsed time.
 struct SendspinTimeFilter {
     // MARK: - State
 
@@ -59,7 +59,7 @@ struct SendspinTimeFilter {
     /// Adaptive forgetting: covariance inflation factor (squared)
     private let forgetVarianceFactor: Double
 
-    /// Adaptive forgetting: residual cutoff as fraction of max_error
+    /// Adaptive forgetting: residual cutoff as a multiple of max_error
     private let adaptiveForgettingCutoff: Double
 
     /// Minimum samples before adaptive forgetting engages
@@ -68,34 +68,46 @@ struct SendspinTimeFilter {
     /// Drift SNR threshold (squared): drift² must exceed this × driftCovariance
     private let driftSignificanceThresholdSquared: Double
 
+    /// Scale factor applied to `maxError` before it is squared into the
+    /// measurement variance. `maxError` (RTT/2) is a worst-case bound, not
+    /// a 1σ estimate, so values < 1 better reflect typical measurement noise.
+    private let maxErrorScale: Double
+
     // MARK: - Init
 
     /// Create a new time filter.
     ///
-    /// Defaults match the reference project's `README.md` "Recommended Values"
-    /// section. In particular, `driftProcessStdDev` defaults to `0.0` — a
-    /// nonzero value causes `driftCovariance` to grow by `dt · q_drift` each
-    /// step, and the `driftCov · dt²` term in the offset prediction then
-    /// pins `offsetCovariance` at `measurementVariance` every cycle (the
-    /// filter stops learning from multiple samples).
-    ///
     /// - Parameters:
-    ///   - processStdDev: Standard deviation of offset process noise. Default 0.01.
-    ///   - driftProcessStdDev: Standard deviation of drift process noise.
-    ///     Default 0.0 — treat drift as effectively constant between samples
-    ///     (valid over minutes for any real oscillator).
-    ///   - forgetFactor: Adaptive forgetting inflation factor (>1). Applied when
-    ///     residuals exceed the cutoff after min_samples. Default 1.001.
-    ///   - adaptiveCutoff: Fraction of max_error that triggers forgetting. Default 0.75.
-    ///   - minSamples: Minimum measurements before forgetting engages. Default 100.
-    ///   - driftSignificanceThreshold: SNR threshold for applying drift. Default 2.0.
+    ///   - processStdDev: Diffusion coefficient for the offset random walk
+    ///     (μs/√μs). Offset variance grows by `processStdDev² · dt` per μs of
+    ///     elapsed time. Default `0.0`.
+    ///   - driftProcessStdDev: Diffusion coefficient for the drift random walk
+    ///     (1/√μs). Drift is dimensionless, so its variance grows by
+    ///     `driftProcessStdDev² · dt` per μs of elapsed time. Default `1e-11`
+    ///     — small enough to behave like zero on short timescales while keeping
+    ///     drift covariance from collapsing to literally zero.
+    ///   - forgetFactor: Covariance inflation factor (>1) applied when large
+    ///     residuals are detected. Higher values enable faster recovery from
+    ///     disruptions but reduce stability. Default `2.0`.
+    ///   - adaptiveCutoff: Multiple of `maxError` that triggers adaptive
+    ///     forgetting. Forgetting fires when `|residual| > adaptiveCutoff · maxError`;
+    ///     values > 1 require larger residuals. Default `3.0`.
+    ///   - minSamples: Minimum measurements before adaptive forgetting engages.
+    ///     Default `100`.
+    ///   - driftSignificanceThreshold: SNR threshold for applying drift. Drift
+    ///     is only used when `drift² > threshold² · driftCovariance`. Default `2.0`.
+    ///   - maxErrorScale: Scale factor applied to `maxError` before it is fed to
+    ///     the Kalman update. `maxError` is a worst-case bound on measurement
+    ///     error, not a 1σ estimate, so using it unscaled over-inflates the
+    ///     measurement variance. Default `0.5`.
     init(
-        processStdDev: Double = 0.01,
-        driftProcessStdDev: Double = 0.0,
-        forgetFactor: Double = 1.001,
-        adaptiveCutoff: Double = 0.75,
+        processStdDev: Double = 0.0,
+        driftProcessStdDev: Double = 1e-11,
+        forgetFactor: Double = 2.0,
+        adaptiveCutoff: Double = 3.0,
         minSamples: UInt8 = 100,
-        driftSignificanceThreshold: Double = 2.0
+        driftSignificanceThreshold: Double = 2.0,
+        maxErrorScale: Double = 0.5
     ) {
         processVariance = processStdDev * processStdDev
         driftProcessVariance = driftProcessStdDev * driftProcessStdDev
@@ -103,6 +115,7 @@ struct SendspinTimeFilter {
         adaptiveForgettingCutoff = adaptiveCutoff
         minSamplesForForgetting = minSamples
         driftSignificanceThresholdSquared = driftSignificanceThreshold * driftSignificanceThreshold
+        self.maxErrorScale = maxErrorScale
     }
 
     // MARK: - Update
@@ -119,9 +132,14 @@ struct SendspinTimeFilter {
         // Guard: timestamps must be strictly monotonic
         guard timeAdded > lastUpdate || count == 0 else { return }
 
-        // Floor max_error to 1μs to prevent zero measurement variance (Rust port fix)
+        // Floor maxError to 1μs to prevent zero measurement variance:
+        // localhost can produce maxError = 0, which would NaN the Kalman gain.
         let clampedMaxError = max(maxError, 1.0)
-        let measurementVariance = clampedMaxError * clampedMaxError
+
+        // Scale before squaring: maxError is a worst-case bound (RTT/2), not
+        // a 1σ estimate, so using it unscaled over-inflates R.
+        let updateStdDev = clampedMaxError * maxErrorScale
+        let measurementVariance = updateStdDev * updateStdDev
 
         let dt = Double(timeAdded - lastUpdate)
 
@@ -231,7 +249,7 @@ struct SendspinTimeFilter {
     }
 
     /// Estimated standard deviation of the offset in microseconds.
-    /// Equivalent to C++ `get_error()`. Returns `nil` before the first measurement.
+    /// Returns `nil` before the first measurement.
     var estimatedError: Double? {
         guard isInitialized else { return nil }
         assert(offsetCovariance >= 0, "Covariance matrix lost positive-semidefiniteness")

--- a/Tests/SendspinKitTests/Synchronization/SendspinTimeFilterTests.swift
+++ b/Tests/SendspinKitTests/Synchronization/SendspinTimeFilterTests.swift
@@ -27,7 +27,8 @@ struct SendspinTimeFilterTests {
         #expect(filter.count == 1)
         #expect(filter.offset == 500.0)
         #expect(filter.drift == 0.0)
-        #expect(filter.offsetCovariance == 2_500.0) // 50²
+        // (maxError · maxErrorScale)² = (50 · 0.5)² = 625
+        #expect(filter.offsetCovariance == 625.0)
     }
 
     @Test
@@ -59,10 +60,9 @@ struct SendspinTimeFilterTests {
         #expect(abs(filter.offset - trueOffset) < 1.0)
         // Drift should be near zero
         #expect(abs(filter.drift) < 0.0001)
-        // Covariance should be much smaller than initial measurement variance (625)
-        // but process noise prevents it from reaching zero
-        #expect(filter.offsetCovariance < 650.0)
-        #expect(filter.offsetCovariance < 2_500.0) // well below initial prior
+        // Initial measurement variance is (25 · 0.5)² = 156.25; steady-state
+        // covariance should be at or below that with consistent measurements.
+        #expect(filter.offsetCovariance < 200.0)
     }
 
     @Test
@@ -86,11 +86,12 @@ struct SendspinTimeFilterTests {
     @Test
     func handlesZeroMaxErrorLocalhost() {
         var filter = SendspinTimeFilter()
-        // maxError of 0 should be floored to 1.0 internally
+        // maxError of 0 should be floored to 1.0μs internally
         filter.update(timeAdded: 1_000, measurement: 500.0, maxError: 0.0)
 
         #expect(filter.isInitialized)
-        #expect(filter.offsetCovariance == 1.0) // 1² = 1
+        // (floor · maxErrorScale)² = (1.0 · 0.5)² = 0.25
+        #expect(filter.offsetCovariance == 0.25)
         #expect(!filter.offset.isNaN)
         #expect(!filter.offsetCovariance.isNaN)
     }
@@ -257,13 +258,12 @@ struct SendspinTimeFilterTests {
     func adaptiveForgettingInflatesCovarianceOnLargeResidual() {
         // This test exercises the adaptive-forgetting path on a large residual.
         // For the inflation to be *visible* in the covariance fields after the
-        // Kalman update's deflation, the filter needs some amount of process
-        // noise building covariance between samples. The library default for
-        // `driftProcessStdDev` is 0.0 (matching the reference README's
-        // recommended tuning), which makes drift covariance monotonically
-        // shrink — the 0.2% forgetting bump then gets swamped. We construct
-        // with a non-zero drift process noise so the inflation path is
-        // observable.
+        // Kalman update's deflation, the filter needs enough drift process
+        // noise to accumulate covariance between samples. The library default
+        // for `driftProcessStdDev` (`1e-11`) is small enough that drift
+        // covariance barely accumulates over the test's timescale, so we
+        // construct with a much larger drift process noise to make the
+        // inflation path unambiguously observable.
         // Use minSamples=5 so we don't need 100 warmup measurements.
         var filter = SendspinTimeFilter(driftProcessStdDev: 0.001, minSamples: 5)
 
@@ -277,8 +277,9 @@ struct SendspinTimeFilterTests {
         let driftCovarianceBefore = filter.driftCovariance
 
         // Inject a measurement with a 9000μs jump from predicted offset.
-        // With maxError=50 and cutoff=0.75, forgetting triggers when |residual| > 37.5μs.
-        // Residual ≈ 9000 >> 37.5, so all three covariances should be inflated.
+        // With maxError=50 and the default cutoff=3.0, forgetting triggers
+        // when |residual| > 150μs. Residual ≈ 9000 >> 150, so all three
+        // covariances are inflated by forgetFactor² = 4.
         filter.update(timeAdded: 1_100_000, measurement: 10_000.0, maxError: 50.0)
 
         // With covariance inflation, offset should jump closer to the outlier (10_000)
@@ -362,10 +363,11 @@ struct SendspinTimeFilterTests {
         var filter = SendspinTimeFilter()
         filter.update(timeAdded: 1_000, measurement: 500.0, maxError: 50.0)
 
-        // After first measurement: offsetCovariance = maxError² = 2500
-        // estimatedError = √2500 = 50.0 (exactly representable in IEEE 754)
+        // After first measurement: offsetCovariance = (maxError · maxErrorScale)²
+        //                                           = (50 · 0.5)² = 625
+        // estimatedError = √625 = 25.0 (exactly representable in IEEE 754)
         let error = try #require(filter.estimatedError)
-        #expect(error == 50.0)
+        #expect(error == 25.0)
     }
 
     @Test


### PR DESCRIPTION
Upstream retuned the time-filter defaults and added a max_error_scale parameter we were missing. Our port was based on an earlier README's "Recommended Values" section that has since been replaced. Bringing the math in line:

- New maxErrorScale parameter (default 0.5): scales maxError before squaring into measurement variance. maxError is RTT/2 — a worst-case bound, not a 1σ estimate — so using it unscaled over-inflated R by ~4× and slowed convergence.
- processStdDev: 0.01 → 0.0
- driftProcessStdDev: 0.0 → 1e-11
- forgetFactor: 1.001 → 2.0
- adaptiveCutoff: 0.75 → 3.0 (semantics also flipped from "fraction" to "multiple")

Retained the 1μs RTT floor from the Rust port — prevents zero-variance NaN when localhost can produce maxError = 0.

Added est=, drift=ppm, samples= fields to the periodic 2s telemetry log in SendspinClient. ClockSynchronizer.diagnosticSnapshot() already exposes everything atomically; the telemetry path now uses it for a single actor-hop read instead of multiple property reads.

Smoke-tested locally against sendspin-cli for 25s in both software and hardware volume modes:
- Software: estimatedError settles at ~85μs (5.9× tighter than RTT/2); drift converges to ~0.3 ppm
- Hardware: estimatedError settles at ~58μs (8.6× tighter than RTT/2); drift converges to ~-3.5 ppm

These cleanly fix the pathology a422b91 originally addressed (the "estimatedError pinned at RTT/2" failure mode); the filter now genuinely learns across samples.

Three test expectations updated for the new R = (maxError · 0.5)² math. 266/266 tests pass; swiftformat + swiftlint clean.