### PR TITLE
fix(client): default client/goodbye reason to restart

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -304,9 +304,12 @@ public final class SendspinClient {
     /// for signal handlers and shutdown paths that may invoke `disconnect()`
     /// more than once (e.g. a user pounding Ctrl-C).
     ///
-    /// - Parameter reason: Why the client is disconnecting. Defaults to `.shutdown`.
+    /// - Parameter reason: Why the client is disconnecting. Defaults to `.restart`,
+    ///   matching the reason a server assumes when a client vanishes without a
+    ///   goodbye. Pass `.shutdown` or `.userRequest` to explicitly tell the
+    ///   server not to auto-reconnect.
     @MainActor
-    public func disconnect(reason: GoodbyeReason = .shutdown) async {
+    public func disconnect(reason: GoodbyeReason = .restart) async {
         // Idempotency guard: a second disconnect() while already disconnected
         // would otherwise re-run teardown on nil state (harmless) and yield a
         // ghost `.disconnected` event (not harmless — it spams event consumers).

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -504,4 +504,22 @@ struct ClientIntegrationTests {
 
         await client.disconnect()
     }
+
+    // MARK: 11. default disconnect sends restart so the server keeps auto-reconnect
+
+    @Test
+    func disconnect_defaultReasonIsRestart() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        let countBefore = await mock.sentTextMessages.count
+        await client.disconnect()
+
+        let messages = await mock.sentTextMessages
+        let goodbye = messages.dropFirst(countBefore).compactMap { data in
+            try? JSONDecoder().decode(ClientGoodbyeMessage.self, from: data)
+        }.last
+        let sent = try #require(goodbye, "Expected a client/goodbye after disconnect()")
+        #expect(sent.payload?.reason == .restart)
+    }
 }


### PR DESCRIPTION
A bare disconnect() previously sent reason `shutdown`, telling the server not to auto-reconnect. Per spec, a graceful disconnect with no explicit reason should match what the server assumes when no goodbye arrives at all — `restart` — so a long-running client stays available for auto-reconnect. Callers that truly mean shutdown still pass it explicitly. Adds a test asserting the on-the-wire goodbye reason.

Closes #15