### PR TITLE
feat(client): report operational error on audio underrun

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -599,6 +599,7 @@ public final class SendspinClient {
     private nonisolated func runSyncCorrectionAndTelemetry() async {
         var lastTelemetryStats = SchedulerStats()
         var tickCount = 0
+        var underrunMonitor = UnderrunMonitor()
 
         while !Task.isCancelled {
             // 500ms poll — reanchors are rare events, no need to check faster.
@@ -613,6 +614,20 @@ public final class SendspinClient {
             // --- Poll for reanchor requests from the audio callback ---
             if let reanchorTarget = await audioPlayer.pollReanchor() {
                 await audioPlayer.reanchorCursor(to: reanchorTarget)
+            }
+
+            let tSnap = await audioPlayer.telemetrySnapshot
+
+            // Report buffer starvation as `error`/`synchronized` (spec §Playback
+            // Synchronization). The audio callback only counts underruns; this
+            // off-thread loop is where we can reach the server.
+            switch await clientOperationalState {
+            case .externalSource:
+                // Re-baseline: underruns accrued while not playing must not trip an
+                // error once we rejoin.
+                underrunMonitor.resetBaseline(underrunCount: tSnap.underrunCount)
+            case .synchronized, .error:
+                await applyUnderrunTransition(underrunMonitor.observe(underrunCount: tSnap.underrunCount))
             }
 
             // --- Telemetry (every 2s = every 4 ticks) ---
@@ -635,8 +650,8 @@ public final class SendspinClient {
                 // human-readable form for clock-drift rates.
                 let driftPpm = syncSnap.drift * 1_000_000.0
 
-                // Read sync error computed by the audio callback (precise, no actor jitter)
-                let tSnap = await audioPlayer.telemetrySnapshot
+                // Sync error computed by the audio callback (precise, no actor jitter);
+                // reuse the per-tick telemetry snapshot read above.
                 let syncErrorUs = tSnap.syncErrorUs
                 let dropN = tSnap.correctionSchedule.dropEveryNFrames
                 let insertN = tSnap.correctionSchedule.insertEveryNFrames
@@ -821,6 +836,24 @@ public final class SendspinClient {
         } catch {
             clientOperationalState = previous
             throw SendspinClientError.sendFailed(error.localizedDescription)
+        }
+    }
+
+    /// Apply an underrun transition from the telemetry loop's ``UnderrunMonitor``.
+    ///
+    /// Guarded to only move `.synchronized` ↔ `.error`, so it can't clobber
+    /// `.externalSource` or a codec/format `.error`. Send failures are ignored;
+    /// the next state change re-syncs the server.
+    func applyUnderrunTransition(_ transition: UnderrunMonitor.Transition) async {
+        switch transition {
+        case .none:
+            break
+        case .toError:
+            guard clientOperationalState == .synchronized else { return }
+            try? await transitionOperationalState(to: .error)
+        case .toSynchronized:
+            guard clientOperationalState == .error else { return }
+            try? await transitionOperationalState(to: .synchronized)
         }
     }
 }

--- a/Sources/SendspinKit/Client/UnderrunMonitor.swift
+++ b/Sources/SendspinKit/Client/UnderrunMonitor.swift
@@ -1,0 +1,59 @@
+// ABOUTME: Pure decision logic for underrun-driven operational-state reporting
+// ABOUTME: Maps telemetry underrun counts to synchronized/error transitions with hysteresis
+
+/// Decides when buffer underruns should move the client between `synchronized`
+/// and `error` (per spec §Playback Synchronization).
+///
+/// Pure value type so the policy is testable without timing or audio hardware.
+/// Hysteresis is deliberately asymmetric — error on the first underrun, recovery
+/// only after `recoveryTicks` clean ticks — to keep `client/state` from flapping.
+struct UnderrunMonitor {
+    enum Transition: Equatable {
+        case none
+        case toError
+        case toSynchronized
+    }
+
+    /// Clean ticks required to recover. At the telemetry loop's 500 ms poll, `2` ≈ 1 s.
+    private let recoveryTicks: Int
+    private var lastUnderrunCount: Int64 = 0
+    private var cleanTicks = 0
+    private var inError = false
+
+    init(recoveryTicks: Int = 2) {
+        self.recoveryTicks = max(1, recoveryTicks)
+    }
+
+    /// Whether the monitor raised the current `error`, so the caller doesn't clear
+    /// an error it didn't set (e.g. a codec failure).
+    var isTrackingError: Bool {
+        inError
+    }
+
+    /// The count resets to zero on a new stream, so a decrease counts as clean.
+    mutating func observe(underrunCount: Int64) -> Transition {
+        defer { lastUnderrunCount = underrunCount }
+
+        if underrunCount > lastUnderrunCount {
+            cleanTicks = 0
+            guard !inError else { return .none }
+            inError = true
+            return .toError
+        }
+
+        guard inError else { return .none }
+        cleanTicks += 1
+        guard cleanTicks >= recoveryTicks else { return .none }
+        cleanTicks = 0
+        inError = false
+        return .toSynchronized
+    }
+
+    /// Re-baseline and drop any tracked error without emitting a transition, for
+    /// when the client isn't participating in playback (external source).
+    mutating func resetBaseline(underrunCount: Int64) {
+        lastUnderrunCount = underrunCount
+        cleanTicks = 0
+        inError = false
+    }
+}

--- a/Tests/SendspinKitTests/Client/UnderrunMonitorTests.swift
+++ b/Tests/SendspinKitTests/Client/UnderrunMonitorTests.swift
@@ -1,0 +1,85 @@
+@testable import SendspinKit
+import Testing
+
+struct UnderrunMonitorTests {
+    @Test
+    func noUnderrunsStaysSynchronized() {
+        var monitor = UnderrunMonitor(recoveryTicks: 2)
+        for _ in 0 ..< 5 {
+            #expect(monitor.observe(underrunCount: 0) == .none)
+        }
+        #expect(monitor.isTrackingError == false)
+    }
+
+    @Test
+    func firstUnderrunEntersError() {
+        var monitor = UnderrunMonitor(recoveryTicks: 2)
+        #expect(monitor.observe(underrunCount: 0) == .none)
+        #expect(monitor.observe(underrunCount: 1) == .toError)
+        #expect(monitor.isTrackingError)
+    }
+
+    @Test
+    func continuedUnderrunsDoNotReemitError() {
+        var monitor = UnderrunMonitor(recoveryTicks: 2)
+        #expect(monitor.observe(underrunCount: 1) == .toError)
+        #expect(monitor.observe(underrunCount: 2) == .none)
+        #expect(monitor.observe(underrunCount: 5) == .none)
+        #expect(monitor.isTrackingError)
+    }
+
+    @Test
+    func recoversOnlyAfterRequiredCleanTicks() {
+        var monitor = UnderrunMonitor(recoveryTicks: 2)
+        #expect(monitor.observe(underrunCount: 1) == .toError)
+        // One clean tick is not enough.
+        #expect(monitor.observe(underrunCount: 1) == .none)
+        #expect(monitor.isTrackingError)
+        // Second consecutive clean tick recovers.
+        #expect(monitor.observe(underrunCount: 1) == .toSynchronized)
+        #expect(monitor.isTrackingError == false)
+    }
+
+    @Test
+    func underrunDuringRecoveryRestartsTheCleanCount() {
+        var monitor = UnderrunMonitor(recoveryTicks: 2)
+        #expect(monitor.observe(underrunCount: 1) == .toError)
+        #expect(monitor.observe(underrunCount: 1) == .none) // clean tick 1
+        #expect(monitor.observe(underrunCount: 2) == .none) // underrun resets the count
+        #expect(monitor.observe(underrunCount: 2) == .none) // clean tick 1 again
+        #expect(monitor.observe(underrunCount: 2) == .toSynchronized) // clean tick 2
+    }
+
+    @Test
+    func counterResetFromStreamRestartIsTreatedAsClean() {
+        var monitor = UnderrunMonitor(recoveryTicks: 2)
+        #expect(monitor.observe(underrunCount: 5) == .toError)
+        // A new stream resets the player's underrun counter to zero.
+        #expect(monitor.observe(underrunCount: 0) == .none) // clean tick 1
+        #expect(monitor.observe(underrunCount: 0) == .toSynchronized) // clean tick 2
+    }
+
+    @Test
+    func resetBaselineClearsErrorAndRebaselines() {
+        var monitor = UnderrunMonitor(recoveryTicks: 2)
+        #expect(monitor.observe(underrunCount: 10) == .toError)
+
+        monitor.resetBaseline(underrunCount: 10)
+        #expect(monitor.isTrackingError == false)
+
+        // Re-baselined at 10: the same count is not a new underrun.
+        #expect(monitor.observe(underrunCount: 10) == .none)
+        // A genuine underrun after rebaselining enters error again.
+        #expect(monitor.observe(underrunCount: 11) == .toError)
+    }
+
+    @Test
+    func recoveryTicksParameterIsHonored() {
+        var monitor = UnderrunMonitor(recoveryTicks: 4)
+        #expect(monitor.observe(underrunCount: 1) == .toError)
+        #expect(monitor.observe(underrunCount: 1) == .none) // 1
+        #expect(monitor.observe(underrunCount: 1) == .none) // 2
+        #expect(monitor.observe(underrunCount: 1) == .none) // 3
+        #expect(monitor.observe(underrunCount: 1) == .toSynchronized) // 4
+    }
+}

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -190,6 +190,17 @@ private func lastSentCommand(from mock: MockTransport, after offset: Int) async 
     }.last
 }
 
+/// Decode the last `ClientStateMessage` payload sent after `offset`.
+///
+/// Uses a plain decoder (no snake-case conversion) because the nested
+/// `PlayerStateObject` defines explicit snake_case `CodingKeys`.
+private func lastClientState(from mock: MockTransport, after offset: Int) async -> ClientStatePayload? {
+    let messages = await mock.sentTextMessages
+    return messages.dropFirst(offset).compactMap { data in
+        try? JSONDecoder().decode(ClientStateMessage.self, from: data)
+    }.last?.payload
+}
+
 // MARK: - Tests
 
 @MainActor
@@ -521,5 +532,53 @@ struct ClientIntegrationTests {
         }.last
         let sent = try #require(goodbye, "Expected a client/goodbye after disconnect()")
         #expect(sent.payload?.reason == .restart)
+    }
+
+    // MARK: 12. underrun-driven operational state reporting is guarded
+
+    @Test
+    func applyUnderrunTransition_toErrorFromSynchronizedReportsError() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        let countBefore = await mock.sentTextMessages.count
+        await client.applyUnderrunTransition(.toError)
+
+        #expect(client.clientOperationalState == .error)
+        let payload = await lastClientState(from: mock, after: countBefore)
+        #expect(payload?.state == .error)
+    }
+
+    @Test
+    func applyUnderrunTransition_toSynchronizedRecoversFromError() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        await client.applyUnderrunTransition(.toError)
+        #expect(client.clientOperationalState == .error)
+
+        let countBefore = await mock.sentTextMessages.count
+        await client.applyUnderrunTransition(.toSynchronized)
+
+        #expect(client.clientOperationalState == .synchronized)
+        let payload = await lastClientState(from: mock, after: countBefore)
+        #expect(payload?.state == .synchronized)
+    }
+
+    @Test
+    func applyUnderrunTransition_toErrorIsIgnoredDuringExternalSource() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        try await client.enterExternalSource()
+        #expect(client.clientOperationalState == .externalSource)
+
+        let countBefore = await mock.sentTextMessages.count
+        await client.applyUnderrunTransition(.toError)
+
+        // The guard must leave external-source untouched and send nothing.
+        #expect(client.clientOperationalState == .externalSource)
+        let sentAfter = await mock.sentTextMessages.count
+        #expect(sentAfter == countBefore)
     }
 }


### PR DESCRIPTION
Buffer underruns in the audio callback only incremented a counter; the client never told the server it had fallen out of sync. Per spec, a client that cannot maintain sync should report state: 'error', then 'synchronized' once it recovers.

Add a pure UnderrunMonitor that turns the telemetry loop's underrun counts into synchronized/error transitions with asymmetric hysteresis (error on first underrun, recovery after ~1s clean) to avoid flapping. The telemetry loop applies transitions through a guarded helper that won't clobber external-source or codec/format error states.

Closes #16