### PR TITLE
feat(sync): require count >= 2 with finite covariance before time conversion

### DIFF
--- a/Sources/SendspinKit/Synchronization/ClockSynchronizer.swift
+++ b/Sources/SendspinKit/Synchronization/ClockSynchronizer.swift
@@ -82,9 +82,9 @@ actor ClockSynchronizer: ClockSyncProtocol {
         Int64(filter.offset.rounded())
     }
 
-    /// Whether at least one sync sample has been accepted
+    /// Whether the filter is synchronized enough to convert times (count >= 2).
     var hasSynced: Bool {
-        filter.isInitialized
+        filter.isSynchronized
     }
 
     /// Process a server/time response to update the clock model.
@@ -136,7 +136,7 @@ actor ClockSynchronizer: ClockSyncProtocol {
     ///   before using the result for playback scheduling. `SendspinClient` enforces this
     ///   by dropping audio chunks until `hasSynced` is true.
     func serverTimeToLocal(_ serverTime: Int64) -> Int64 {
-        guard filter.isInitialized else {
+        guard filter.isSynchronized else {
             // No sync data yet — assume zero offset. This produces a value in the
             // correct absolute-time domain but with an unknown error equal to the
             // true server-client offset. Only useful as a placeholder until the
@@ -155,7 +155,7 @@ actor ClockSynchronizer: ClockSyncProtocol {
     /// - Important: Before the first successful sync, assumes zero offset.
     ///   See ``serverTimeToLocal(_:)`` for details.
     func localTimeToServer(_ localTime: Int64) -> Int64 {
-        guard filter.isInitialized else {
+        guard filter.isSynchronized else {
             return localTime - clientProcessStartAbsolute
         }
 
@@ -185,7 +185,7 @@ actor ClockSynchronizer: ClockSyncProtocol {
     /// Create an immutable snapshot of the current filter state for audio-thread use.
     /// Returns `nil` before the first successful sync.
     func snapshot() -> TimeFilterSnapshot? {
-        guard filter.isInitialized else { return nil }
+        guard filter.isSynchronized else { return nil }
         return TimeFilterSnapshot(
             offset: filter.offset,
             drift: filter.drift,

--- a/Sources/SendspinKit/Synchronization/SendspinTimeFilter.swift
+++ b/Sources/SendspinKit/Synchronization/SendspinTimeFilter.swift
@@ -243,9 +243,17 @@ struct SendspinTimeFilter {
 
     // MARK: - Diagnostics
 
-    /// Whether the filter has received at least one measurement
+    /// Whether the filter has received at least one measurement (offset is set).
+    /// Gates diagnostics; time conversion requires the stricter ``isSynchronized``.
     var isInitialized: Bool {
         count > 0
+    }
+
+    /// Whether the filter can produce a usable time conversion: at least two
+    /// measurements (so drift is established from finite differences) and a
+    /// finite offset covariance.
+    var isSynchronized: Bool {
+        count >= 2 && offsetCovariance.isFinite
     }
 
     /// Estimated standard deviation of the offset in microseconds.

--- a/Tests/SendspinKitTests/Integration/ClockSyncIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClockSyncIntegrationTests.swift
@@ -58,12 +58,20 @@ struct ClockSyncIntegrationTests {
     func timeConversionMaintainsBidirectionalAccuracy() async {
         let sync = ClockSynchronizer()
 
-        // Initialize with known offset
+        // Initialize with known offset. Two rounds: the filter needs count >= 2
+        // before time conversion applies the offset (otherwise both directions
+        // hit the zero-offset placeholder and the round-trip passes trivially).
         await sync.processServerTime(
             clientTransmitted: 1_000,
             serverReceived: 1_500,
             serverTransmitted: 1_505,
             clientReceived: 2_005
+        )
+        await sync.processServerTime(
+            clientTransmitted: 3_000,
+            serverReceived: 3_500,
+            serverTransmitted: 3_505,
+            clientReceived: 4_005
         )
 
         let testServerTime: Int64 = 10_000

--- a/Tests/SendspinKitTests/Synchronization/ClockSynchronizerTests.swift
+++ b/Tests/SendspinKitTests/Synchronization/ClockSynchronizerTests.swift
@@ -66,12 +66,19 @@ struct ClockSynchronizerTests {
     func convertServerTimeToLocalTime() async {
         let sync = ClockSynchronizer()
 
-        // Server ahead by 200, symmetric 100us delays
+        // Server ahead by 200, symmetric 100us delays. Two rounds: the filter
+        // needs count >= 2 before serverTimeToLocal applies the offset.
         await sync.processServerTime(
             clientTransmitted: 1_000,
             serverReceived: 1_300, // 1000 + 100 delay + 200 offset
             serverTransmitted: 1_305,
             clientReceived: 1_405 // 1305 + 100 delay
+        )
+        await sync.processServerTime(
+            clientTransmitted: 2_000,
+            serverReceived: 2_300,
+            serverTransmitted: 2_305,
+            clientReceived: 2_405
         )
         // offset = ((1300-1000) + (1305-1405)) / 2 = (300 + -100) / 2 = 100
 

--- a/Tests/SendspinKitTests/Synchronization/SendspinTimeFilterTests.swift
+++ b/Tests/SendspinKitTests/Synchronization/SendspinTimeFilterTests.swift
@@ -23,7 +23,9 @@ struct SendspinTimeFilterTests {
         var filter = SendspinTimeFilter()
         filter.update(timeAdded: 1_000, measurement: 500.0, maxError: 50.0)
 
+        // One measurement sets the offset (initialized) but isn't yet synchronized.
         #expect(filter.isInitialized)
+        #expect(!filter.isSynchronized)
         #expect(filter.count == 1)
         #expect(filter.offset == 500.0)
         #expect(filter.drift == 0.0)
@@ -41,6 +43,19 @@ struct SendspinTimeFilterTests {
         #expect(filter.offset == 510.0)
         // drift = (510 - 500) / (2000 - 1000) = 0.01
         #expect(filter.drift == 0.01)
+    }
+
+    @Test
+    func synchronizationRequiresTwoMeasurements() {
+        var filter = SendspinTimeFilter()
+        #expect(!filter.isSynchronized)
+
+        filter.update(timeAdded: 1_000, measurement: 500.0, maxError: 50.0)
+        #expect(!filter.isSynchronized) // one sample: offset only, no drift yet
+
+        filter.update(timeAdded: 2_000, measurement: 510.0, maxError: 50.0)
+        #expect(filter.isSynchronized)
+        #expect(filter.offsetCovariance.isFinite)
     }
 
     // MARK: - Convergence


### PR DESCRIPTION
The time filter exposed a single readiness predicate (isInitialized, count > 0) used both for diagnostics and to gate time conversion. One measurement only fixes the offset — drift is still unknown — so converting server timestamps after a single sample is premature.

Split the two concerns: isInitialized keeps its honest meaning (count > 0, gates diagnostics), and a new isSynchronized (count >= 2 && finite offset covariance) gates time conversion. ClockSynchronizer's conversion paths (hasSynced, serverTimeToLocal, localTimeToServer, snapshot) now use isSynchronized; diagnostics (estimatedError, diagnosticSnapshot) keep isInitialized, preserving their single-sample availability. This mirrors the separate is_synchronized() readiness gate in the Rust and Python ports.

Closes #17