### PR TITLE
feat(client): persist last-played server via SendspinPersistenceProvider

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
@@ -368,9 +368,11 @@ extension SendspinClient {
 
     func handleGroupUpdate(_ message: GroupUpdateMessage) async {
         // Per spec: persist server_id when playback_state transitions to 'playing'.
-        // Emitted as an event so the host app can persist using its own storage.
+        // Persisted via the injected provider (the storage path used by arbitration)
+        // and also surfaced as an event for observation (e.g. UI).
         if message.payload.playbackState == .playing, let serverId = currentServerId {
             eventsContinuation.yield(.lastPlayedServerChanged(serverId: serverId))
+            await persistenceProvider?.saveLastPlayedServerId(serverId)
         }
 
         // Per spec: "Contains delta updates with only the changed fields.

--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -15,6 +15,10 @@ public final class SendspinClient {
     let roles: Set<VersionedRole>
     let playerConfig: PlayerConfiguration?
     let artworkConfig: ArtworkConfiguration?
+    /// Optional storage hook for the spec's "last played server" bookkeeping.
+    /// Saved on every `group/update` that reports playback started; read by the
+    /// multi-server arbitration tiebreak.
+    let persistenceProvider: (any SendspinPersistenceProvider)?
     /// Resolved volume capabilities and control implementation
     let volumeCapabilities: VolumeCapabilities
     let volumeControl: VolumeControl
@@ -90,7 +94,8 @@ public final class SendspinClient {
         name: String,
         roles: Set<VersionedRole>,
         playerConfig: PlayerConfiguration? = nil,
-        artworkConfig: ArtworkConfiguration? = nil
+        artworkConfig: ArtworkConfiguration? = nil,
+        persistenceProvider: (any SendspinPersistenceProvider)? = nil
     ) throws(ConfigurationError) {
         if roles.contains(.playerV1), playerConfig == nil {
             throw .playerRoleRequiresConfiguration
@@ -104,6 +109,7 @@ public final class SendspinClient {
         self.roles = roles
         self.playerConfig = playerConfig
         self.artworkConfig = artworkConfig
+        self.persistenceProvider = persistenceProvider
         staticDelayMs = playerConfig?.initialStaticDelayMs ?? 0
 
         // Resolve volume mode into concrete capabilities and control implementation

--- a/Sources/SendspinKit/Client/SendspinPersistenceProvider.swift
+++ b/Sources/SendspinKit/Client/SendspinPersistenceProvider.swift
@@ -1,0 +1,26 @@
+// ABOUTME: Persistence hook for the spec's multi-server "last played server" bookkeeping
+// ABOUTME: Lets the host store and restore the server_id used for arbitration tiebreaks
+
+import Foundation
+
+/// Storage hook for the spec's "last played server" bookkeeping.
+///
+/// The Sendspin multi-server rules require a client to *persistently* remember the
+/// `server_id` of the server that most recently had `playback_state: playing`. When
+/// two servers compete and both connect with `connection_reason: discovery`, the
+/// client breaks the tie in favor of that remembered server.
+///
+/// ``SendspinClient`` calls ``saveLastPlayedServerId(_:)`` whenever a `group/update`
+/// reports that playback has started, and ``loadLastPlayedServerId()`` when it needs
+/// the stored value for arbitration. Back it with whatever storage is appropriate —
+/// `UserDefaults`, a file, the keychain, etc.
+///
+/// Methods are `async` so implementations may perform I/O off the main actor, and the
+/// protocol is `Sendable` because the provider is shared across concurrency domains.
+public protocol SendspinPersistenceProvider: Sendable {
+    /// The persisted last-played `server_id`, or `nil` if none has been stored yet.
+    func loadLastPlayedServerId() async -> String?
+
+    /// Persist `serverId` as the most recently playing server.
+    func saveLastPlayedServerId(_ serverId: String) async
+}

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -75,7 +75,10 @@ private func setStaticDelayCommandJSON(_ delayMs: Int) throws -> String {
 
 /// Create a SendspinClient configured for testing with both player and controller roles.
 @MainActor
-private func makeTestClient(roles: Set<VersionedRole> = [.playerV1, .controllerV1]) throws -> SendspinClient {
+private func makeTestClient(
+    roles: Set<VersionedRole> = [.playerV1, .controllerV1],
+    persistenceProvider: (any SendspinPersistenceProvider)? = nil
+) throws -> SendspinClient {
     var playerConfig: PlayerConfiguration?
     if roles.contains(.playerV1) {
         playerConfig = try PlayerConfiguration(
@@ -90,8 +93,43 @@ private func makeTestClient(roles: Set<VersionedRole> = [.playerV1, .controllerV
         clientId: "test-client",
         name: "Test Client",
         roles: roles,
-        playerConfig: playerConfig
+        playerConfig: playerConfig,
+        persistenceProvider: persistenceProvider
     )
+}
+
+/// In-memory ``SendspinPersistenceProvider`` for tests. Records every saved
+/// `server_id` and serves a preloaded value back from `load`.
+private actor MockPersistenceProvider: SendspinPersistenceProvider {
+    private(set) var savedServerIds: [String] = []
+    private var storedServerId: String?
+
+    init(stored storedServerId: String? = nil) {
+        self.storedServerId = storedServerId
+    }
+
+    func loadLastPlayedServerId() async -> String? {
+        storedServerId
+    }
+
+    func saveLastPlayedServerId(_ serverId: String) async {
+        savedServerIds.append(serverId)
+        storedServerId = serverId
+    }
+}
+
+/// Poll `condition` until it returns `true` or the deadline passes.
+/// Returns the final evaluation so callers can assert positively or negatively.
+private func waitUntil(
+    timeout: Duration = .seconds(2),
+    _ condition: @Sendable () async -> Bool
+) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await condition() { return true }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    return await condition()
 }
 
 /// Accept a mock transport connection and wait for the handshake to complete.
@@ -268,6 +306,46 @@ struct ClientIntegrationTests {
 
         let event = await eventTask.value
         #expect(event == .lastPlayedServerChanged(serverId: testServerId))
+
+        await client.disconnect()
+    }
+
+    @Test
+    func groupUpdate_withPlayingSavesServerIdToProvider() async throws {
+        let provider = MockPersistenceProvider()
+        let client = try makeTestClient(persistenceProvider: provider)
+        let mock = try await connectClient(client)
+
+        try await mock.injectText(groupUpdateJSON(
+            groupId: "group-1",
+            groupName: "Living Room",
+            playbackState: .playing
+        ))
+
+        let saved = await waitUntil { await provider.savedServerIds == [testServerId] }
+        #expect(saved, "Expected the provider to persist the last-played server_id")
+
+        await client.disconnect()
+    }
+
+    @Test
+    func groupUpdate_withStoppedDoesNotSaveServerId() async throws {
+        let provider = MockPersistenceProvider()
+        let client = try makeTestClient(persistenceProvider: provider)
+        let mock = try await connectClient(client)
+
+        try await mock.injectText(groupUpdateJSON(
+            groupId: "group-1",
+            groupName: "Living Room",
+            playbackState: .stopped
+        ))
+
+        // Negative assertion: give the message time to be processed, then confirm
+        // nothing was persisted. A non-playing update must not touch storage.
+        let savedSomething = await waitUntil(timeout: .milliseconds(200)) {
+            await !provider.savedServerIds.isEmpty
+        }
+        #expect(!savedSomething, "Stopped playback must not persist a last-played server")
 
         await client.disconnect()
     }


### PR DESCRIPTION
Add an optional SendspinPersistenceProvider injected into SendspinClient. On group/update with playback_state: playing, the client saves the current server_id through the provider -- the storage path the multi-server arbitration tiebreak will read -- alongside the existing .lastPlayedServerChanged observation event.

The provider's loadLastPlayedServerId() read-back contract lands here; its production consumer (handshake-first arbitration) follows separately.