### PR TITLE
feat(client): handshake-first multi-server arbitration

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
@@ -99,6 +99,11 @@ extension SendspinClient {
         // double-tap burst (first two samples 10 ms apart) internally;
         // `isClockSynced` flips event-driven in `handleServerTime` when
         // the first server/time response arrives.
+        //
+        // Cancel any prior task first: a server may re-send server/hello on the
+        // same connection, and reassigning without cancelling would orphan the
+        // previous clock-sync task (it would keep sending client/time forever).
+        clockSyncTask?.cancel()
         clockSyncTask = Task.detached { [weak self] in
             await self?.runClockSync()
         }

--- a/Sources/SendspinKit/Client/SendspinClient+MultiServer.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MultiServer.swift
@@ -1,0 +1,129 @@
+// ABOUTME: Multi-server arbitration for SendspinClient (handshake-first switching)
+// ABOUTME: Decides whether a competing server connection should displace the active one
+
+import Foundation
+
+/// Thrown internally when a competing connection's handshake does not complete
+/// (no `server/hello` before the timeout, or the socket closed first). Caught in
+/// arbitration to fall back to keeping the existing connection.
+private struct HandshakeIncomplete: Error {}
+
+extension SendspinClient {
+    /// Outcome of multi-server arbitration when a second server connects.
+    enum ArbitrationDecision: Equatable {
+        case switchToNew
+        case keepExisting
+    }
+
+    /// Decide whether to switch to a newly-connected server, per the spec's
+    /// multiple-servers rules. Pure (no I/O) so the full decision table is
+    /// exhaustively unit-testable.
+    ///
+    /// - new `playback` always wins (a server wants this client for playback).
+    /// - new `discovery` never displaces an existing `playback`.
+    /// - both `discovery`: switch only if the new server is the persisted
+    ///   last-played one, otherwise keep whoever is already connected.
+    nonisolated static func arbitrate(
+        newReason: ConnectionReason,
+        existingReason: ConnectionReason,
+        newServerId: String,
+        lastPlayedServerId: String?
+    ) -> ArbitrationDecision {
+        switch (newReason, existingReason) {
+        case (.playback, _):
+            return .switchToNew
+        case (.discovery, .playback):
+            return .keepExisting
+        case (.discovery, .discovery):
+            if let lastPlayedServerId, newServerId == lastPlayedServerId {
+                return .switchToNew
+            }
+            return .keepExisting
+        }
+    }
+
+    /// Handle a competing server connection per the spec's multi-server rules.
+    ///
+    /// Completes the `client/hello` ↔ `server/hello` handshake on the *new*
+    /// connection first (without disturbing the active connection), then applies
+    /// ``arbitrate(newReason:existingReason:newServerId:existingServerId:lastPlayedServerId:)``.
+    /// On a switch we leave the current server with `another_server` and adopt the
+    /// new one; otherwise we send the new (losing) server `another_server` and drop it.
+    @MainActor
+    func handleCompetingConnection(_ newTransport: any SendspinTransport) async throws {
+        let hello: ServerHelloMessage
+        do {
+            hello = try await performHandshake(on: newTransport)
+        } catch {
+            // The new server never completed its handshake — keep the existing one.
+            await newTransport.disconnect()
+            return
+        }
+
+        let lastPlayed = await persistenceProvider?.loadLastPlayedServerId()
+        let decision = Self.arbitrate(
+            newReason: hello.payload.connectionReason,
+            existingReason: currentConnectionReason ?? .discovery,
+            newServerId: hello.payload.serverId,
+            lastPlayedServerId: lastPlayed
+        )
+
+        switch decision {
+        case .keepExisting:
+            try? await newTransport.send(
+                ClientGoodbyeMessage(payload: GoodbyePayload(reason: .anotherServer))
+            )
+            await newTransport.disconnect()
+        case .switchToNew:
+            await disconnect(reason: .anotherServer)
+            updateConnectionState(.connecting)
+            try await setupConnection(with: newTransport, preReadHello: hello)
+        }
+    }
+
+    /// Send `client/hello` on `transport` and read its message stream until the
+    /// first `server/hello`, which is returned. Reads only `transport`'s own
+    /// stream and never touches `self.transport`, so it is safe to run against a
+    /// competing connection while another is active.
+    ///
+    /// - Throws: `HandshakeIncomplete` if the stream ends or `timeout` elapses
+    ///   before a `server/hello` arrives.
+    @MainActor
+    private func performHandshake(
+        on transport: any SendspinTransport,
+        timeout: Duration = .seconds(5)
+    ) async throws -> ServerHelloMessage {
+        try await transport.send(ClientHelloMessage(payload: buildClientHelloPayload()))
+
+        return try await withThrowingTaskGroup(of: ServerHelloMessage?.self) { group in
+            group.addTask {
+                for await text in transport.textMessages {
+                    if let hello = Self.decodeServerHello(text) {
+                        return hello
+                    }
+                    // server/hello is the first message per spec; ignore anything before it.
+                }
+                return nil // stream ended without a server/hello
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                return nil // timed out
+            }
+            defer { group.cancelAll() }
+            if let hello = try await group.next() ?? nil {
+                return hello
+            }
+            throw HandshakeIncomplete()
+        }
+    }
+
+    /// Decode a raw text frame as a `server/hello`, or `nil` if it is a different
+    /// message type. Mirrors the type-first dispatch in `handleTextMessage`.
+    private nonisolated static func decodeServerHello(_ text: String) -> ServerHelloMessage? {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              json["type"] as? String == "server/hello"
+        else { return nil }
+        return try? JSONDecoder().decode(ServerHelloMessage.self, from: data)
+    }
+}

--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -247,8 +247,17 @@ public final class SendspinClient {
     }
 
     /// Common setup for both client-initiated and server-initiated connections.
+    ///
+    /// - Parameter preReadHello: When non-nil, the `client/hello` was already sent
+    ///   and the `server/hello` already consumed during competing-connection
+    ///   arbitration. In that case we process the hello directly instead of sending
+    ///   another `client/hello`, and the message loop resumes the transport's stream
+    ///   from the (buffered) frames that follow.
     @MainActor
-    private func setupConnection(with transport: any SendspinTransport) async throws {
+    func setupConnection(
+        with transport: any SendspinTransport,
+        preReadHello: ServerHelloMessage? = nil
+    ) async throws {
         let clockSync = ClockSynchronizer()
         let audioScheduler = AudioScheduler(clockSync: clockSync)
 
@@ -278,7 +287,14 @@ public final class SendspinClient {
             shouldEmitRawAudio = playerConfig.emitRawAudioEvents
         }
 
-        try await sendClientHello()
+        if let preReadHello {
+            // Competing-connection path: client/hello already sent and server/hello
+            // already read during arbitration. Process it before the loop starts so
+            // clock sync is running by the time subsequent frames are dispatched.
+            await handleServerHello(preReadHello)
+        } else {
+            try await sendClientHello()
+        }
 
         let textStream = transport.textMessages
         let binaryStream = transport.binaryMessages
@@ -371,34 +387,10 @@ public final class SendspinClient {
         eventsContinuation.yield(.disconnected(reason: .explicit(reason)))
     }
 
-    // MARK: - Multi-server logic
-
-    /// Handle a competing server connection per the spec's multi-server rules.
-    ///
-    /// The spec says to complete the handshake with the new server before deciding.
-    /// However, reading server/hello from a separate stream would consume other
-    /// messages (like stream/start) that the normal message loop needs. Instead,
-    /// we take a simpler approach: switch to the new server unconditionally and
-    /// let the normal handleServerHello track the connection reason. If the old
-    /// server had playback priority, it will reconnect and reclaim us.
-    ///
-    /// This matches the real-world behavior: servers reconnect with
-    /// connection_reason: playback when they need a client for playback.
-    @MainActor
-    private func handleCompetingConnection(_ newTransport: any SendspinTransport) async throws {
-        // Disconnect old server with 'another_server'
-        await disconnect(reason: .anotherServer)
-
-        // Set up normally with new transport — the regular message loop
-        // will handle server/hello (tracking connectionReason) and stream/start
-        connectionState = .connecting
-        try await setupConnection(with: newTransport)
-    }
-
     // MARK: - Outbound messages
 
     /// Build the client/hello payload (used by both connect paths)
-    private func buildClientHelloPayload() -> ClientHelloPayload {
+    func buildClientHelloPayload() -> ClientHelloPayload {
         var playerV1Support: PlayerSupport?
         if roles.contains(.playerV1), let playerConfig {
             playerV1Support = PlayerSupport(

--- a/Tests/SendspinKitTests/Client/MultiServerArbitrationTests.swift
+++ b/Tests/SendspinKitTests/Client/MultiServerArbitrationTests.swift
@@ -1,0 +1,82 @@
+// ABOUTME: Unit tests for the pure multi-server arbitration decision function
+// ABOUTME: Exercises the full spec decision table without any I/O
+
+@testable import SendspinKit
+import Testing
+
+struct MultiServerArbitrationTests {
+    private let newId = "new-server"
+    private let existingId = "existing-server"
+
+    @Test
+    func newPlaybackBeatsExistingDiscovery() {
+        #expect(SendspinClient.arbitrate(
+            newReason: .playback,
+            existingReason: .discovery,
+            newServerId: newId,
+            lastPlayedServerId: nil
+        ) == .switchToNew)
+    }
+
+    @Test
+    func newPlaybackBeatsExistingPlayback() {
+        #expect(SendspinClient.arbitrate(
+            newReason: .playback,
+            existingReason: .playback,
+            newServerId: newId,
+            lastPlayedServerId: nil
+        ) == .switchToNew)
+    }
+
+    /// A `discovery` connection must never displace an active `playback` server,
+    /// even when the new server happens to be the last-played one.
+    @Test
+    func newDiscoveryYieldsToExistingPlayback() {
+        #expect(SendspinClient.arbitrate(
+            newReason: .discovery,
+            existingReason: .playback,
+            newServerId: newId,
+            lastPlayedServerId: newId
+        ) == .keepExisting)
+    }
+
+    @Test
+    func bothDiscoveryLastPlayedIsNewSwitches() {
+        #expect(SendspinClient.arbitrate(
+            newReason: .discovery,
+            existingReason: .discovery,
+            newServerId: newId,
+            lastPlayedServerId: newId
+        ) == .switchToNew)
+    }
+
+    @Test
+    func bothDiscoveryLastPlayedIsExistingKeeps() {
+        #expect(SendspinClient.arbitrate(
+            newReason: .discovery,
+            existingReason: .discovery,
+            newServerId: newId,
+            lastPlayedServerId: existingId
+        ) == .keepExisting)
+    }
+
+    @Test
+    func bothDiscoveryNoLastPlayedKeeps() {
+        #expect(SendspinClient.arbitrate(
+            newReason: .discovery,
+            existingReason: .discovery,
+            newServerId: newId,
+            lastPlayedServerId: nil
+        ) == .keepExisting)
+    }
+
+    @Test
+    func bothDiscoveryUnrelatedLastPlayedKeeps() {
+        #expect(SendspinClient.arbitrate(
+            newReason: .discovery,
+            existingReason: .discovery,
+            newServerId: newId,
+            lastPlayedServerId: "third-server"
+        ) == .keepExisting)
+    }
+}

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -228,6 +228,42 @@ private func lastSentCommand(from mock: MockTransport, after offset: Int) async 
     }.last
 }
 
+/// Drive a competing connection to completion: start `acceptConnection` and,
+/// concurrently, inject the new server's `server/hello` (which `performHandshake`
+/// blocks on). Returns the new mock once `acceptConnection` resolves.
+@MainActor
+private func acceptCompeting(
+    _ client: SendspinClient,
+    serverId: String,
+    connectionReason: ConnectionReason,
+    activeRoles: [VersionedRole] = [.playerV1, .controllerV1]
+) async throws -> MockTransport {
+    let mock = MockTransport()
+    async let accepted: Void = client.acceptConnection(mock)
+    try await mock.injectText(serverHelloJSON(
+        serverId: serverId,
+        activeRoles: activeRoles,
+        connectionReason: connectionReason
+    ))
+    try await accepted
+    return mock
+}
+
+/// Reasons from every `client/goodbye` the client sent on `mock`.
+///
+/// `ClientGoodbyeMessage`'s synthesized decoder overwrites its constant `type`
+/// from the JSON, so other message types decode "successfully" — filter on the
+/// decoded `type` to keep only real goodbyes.
+private func sentGoodbyeReasons(from mock: MockTransport) async -> [GoodbyeReason] {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let messages = await mock.sentTextMessages
+    return messages
+        .compactMap { try? decoder.decode(ClientGoodbyeMessage.self, from: $0) }
+        .filter { $0.type == "client/goodbye" }
+        .compactMap { $0.payload?.reason }
+}
+
 /// Decode the last `ClientStateMessage` payload sent after `offset`.
 ///
 /// Uses a plain decoder (no snake-case conversion) because the nested
@@ -243,7 +279,7 @@ private func lastClientState(from mock: MockTransport, after offset: Int) async 
 
 @MainActor
 struct ClientIntegrationTests {
-    // MARK: 1. Rollback on external source failure
+    // MARK: Rollback on external source failure
 
     @Test
     func enterExternalSource_rollsBackOnSendFailure() async throws {
@@ -261,7 +297,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 2. streamCleared event
+    // MARK: streamCleared event
 
     @Test
     func streamClear_injectsStreamClearedEvent() async throws {
@@ -284,7 +320,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 3. lastPlayedServerChanged event
+    // MARK: lastPlayedServerChanged event
 
     @Test
     func groupUpdate_withPlayingEmitsLastPlayedServerChanged() async throws {
@@ -350,7 +386,133 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 4. setRepeatMode and setShuffle wire format
+    // MARK: Multi-server arbitration (handshake-first)
+
+    @Test
+    func competingPlayback_overExistingDiscovery_switches() async throws {
+        let client = try makeTestClient()
+        let mock1 = try await connectClient(client, connectionReason: .discovery)
+        let newServerId = "server-2"
+
+        let mock2 = try await acceptCompeting(client, serverId: newServerId, connectionReason: .playback)
+
+        #expect(client.currentServerId == newServerId)
+        #expect(client.connectionState == .connected)
+        // Left the old server with `another_server`, and dropped it.
+        let oldGoodbyes = await sentGoodbyeReasons(from: mock1)
+        let oldDisconnected = await mock1.disconnectCalled
+        let newDisconnected = await mock2.disconnectCalled
+        #expect(oldGoodbyes == [.anotherServer])
+        #expect(oldDisconnected)
+        #expect(!newDisconnected)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func competingDiscovery_underExistingPlayback_keepsExisting() async throws {
+        let client = try makeTestClient()
+        let mock1 = try await connectClient(client, connectionReason: .playback)
+
+        let mock2 = try await acceptCompeting(client, serverId: "server-2", connectionReason: .discovery)
+
+        #expect(client.currentServerId == testServerId)
+        #expect(client.connectionState == .connected)
+        // The losing (new) server is told `another_server` and dropped; old untouched.
+        let newGoodbyes = await sentGoodbyeReasons(from: mock2)
+        let newDisconnected = await mock2.disconnectCalled
+        let oldDisconnected = await mock1.disconnectCalled
+        #expect(newGoodbyes == [.anotherServer])
+        #expect(newDisconnected)
+        #expect(!oldDisconnected)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func competingDiscovery_bothDiscoveryLastPlayedIsNew_switches() async throws {
+        let newServerId = "server-2"
+        let provider = MockPersistenceProvider(stored: newServerId)
+        let client = try makeTestClient(persistenceProvider: provider)
+        let mock1 = try await connectClient(client, connectionReason: .discovery)
+
+        _ = try await acceptCompeting(client, serverId: newServerId, connectionReason: .discovery)
+
+        #expect(client.currentServerId == newServerId)
+        #expect(await mock1.disconnectCalled)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func competingDiscovery_bothDiscoveryNoLastPlayed_keepsExisting() async throws {
+        let client = try makeTestClient()
+        let mock1 = try await connectClient(client, connectionReason: .discovery)
+
+        let mock2 = try await acceptCompeting(client, serverId: "server-2", connectionReason: .discovery)
+
+        let newDisconnected = await mock2.disconnectCalled
+        let oldDisconnected = await mock1.disconnectCalled
+        #expect(client.currentServerId == testServerId)
+        #expect(newDisconnected)
+        #expect(!oldDisconnected)
+
+        await client.disconnect()
+    }
+
+    /// A new server whose handshake never completes must not disturb the existing
+    /// connection. Closing the new transport's streams makes `performHandshake`
+    /// fail fast (no 5 s timeout wait).
+    @Test
+    func competingConnection_handshakeNeverCompletes_keepsExisting() async throws {
+        let client = try makeTestClient()
+        let mock1 = try await connectClient(client, connectionReason: .discovery)
+
+        let mock2 = MockTransport()
+        async let accepted: Void = client.acceptConnection(mock2)
+        try await mock2.finishStreams() // never sends server/hello
+        try await accepted
+
+        let oldDisconnected = await mock1.disconnectCalled
+        let newDisconnected = await mock2.disconnectCalled
+        #expect(client.currentServerId == testServerId)
+        #expect(client.connectionState == .connected)
+        #expect(!oldDisconnected)
+        #expect(newDisconnected)
+
+        await client.disconnect()
+    }
+
+    /// On a switch, frames the new server sent immediately after `server/hello`
+    /// must still be processed once the message loop resumes the (already-read)
+    /// stream. Guards the sequential-iterator handoff in `performHandshake`.
+    @Test
+    func competingSwitch_processesFramesBufferedAfterHello() async throws {
+        let client = try makeTestClient()
+        _ = try await connectClient(client, connectionReason: .discovery)
+        let newServerId = "server-2"
+
+        let mock2 = MockTransport()
+        async let accepted: Void = client.acceptConnection(mock2)
+        try await mock2.injectText(serverHelloJSON(serverId: newServerId, connectionReason: .playback))
+        try await mock2.injectText(groupUpdateJSON(
+            groupId: "group-2",
+            groupName: "Kitchen",
+            playbackState: .playing
+        ))
+        try await accepted
+
+        let sawPlaying = await waitUntil {
+            let state = await MainActor.run { client.currentGroup?.playbackState }
+            return state == .playing
+        }
+        #expect(sawPlaying, "Frame buffered after server/hello must be handled once the loop resumes")
+        #expect(client.currentServerId == newServerId)
+
+        await client.disconnect()
+    }
+
+    // MARK: setRepeatMode and setShuffle wire format
 
     @Test
     func setRepeatMode_oneSendsCorrectCommand() async throws {
@@ -384,7 +546,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 5. sendFailed wrapping
+    // MARK: sendFailed wrapping
 
     @Test
     func play_throwsSendFailedWhenTransportFails() async throws {
@@ -404,7 +566,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 6. activeRoles populated from server/hello
+    // MARK: activeRoles populated from server/hello
 
     @Test
     func serverHello_populatesActiveRoles() async throws {
@@ -439,7 +601,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 7. rawAudioChunk emitted for chunks arriving before stream/start
+    // MARK: rawAudioChunk emitted for chunks arriving before stream/start
 
     @Test
     func rawAudioChunks_emittedEvenWhenArrivingBeforeStreamStart() async throws {
@@ -531,7 +693,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 8. connect throws alreadyConnected
+    // MARK: connect throws alreadyConnected
 
     @Test
     func connect_throwsAlreadyConnectedWhenConnected() async throws {
@@ -545,7 +707,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 9. set_static_delay server command drives state and notifies the host
+    // MARK: set_static_delay server command drives state and notifies the host
 
     @Test
     func serverSetStaticDelay_updatesStateAndEmitsChangedEvent() async throws {
@@ -569,7 +731,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 10. set_static_delay clamps out-of-range server input to the spec maximum
+    // MARK: set_static_delay clamps out-of-range server input to the spec maximum
 
     @Test
     func serverSetStaticDelay_clampsAboveMaximumToSpecLimit() async throws {
@@ -594,7 +756,7 @@ struct ClientIntegrationTests {
         await client.disconnect()
     }
 
-    // MARK: 11. default disconnect sends restart so the server keeps auto-reconnect
+    // MARK: default disconnect sends restart so the server keeps auto-reconnect
 
     @Test
     func disconnect_defaultReasonIsRestart() async throws {
@@ -612,7 +774,7 @@ struct ClientIntegrationTests {
         #expect(sent.payload?.reason == .restart)
     }
 
-    // MARK: 12. underrun-driven operational state reporting is guarded
+    // MARK: underrun-driven operational state reporting is guarded
 
     @Test
     func applyUnderrunTransition_toErrorFromSynchronizedReportsError() async throws {


### PR DESCRIPTION
Replace the unconditional switch on a competing server connection with the spec's decision table. A second server now completes its client/hello <-> server/hello handshake in isolation -- without disturbing the active connection -- and SendspinClient.arbitrate then decides:

- new playback always wins
- new discovery never displaces an existing playback
- both discovery: switch only if the new server is the persisted last-played one (read back via SendspinPersistenceProvider), else keep existing

The losing connection is sent client/goodbye(another_server) before being dropped. Also cancel any prior clock-sync task before starting a new one (a re-sent server/hello would otherwise orphan it), and move the multi-server logic into SendspinClient+MultiServer.swift to keep SendspinClient.swift under the 900-line limit. Drop the brittle sequential numbers from the integration-test MARK headers.

Refs #18 (multi-server arbitration; client reconnect/backoff intentionally out of scope).