### PR TITLE
feat(client): send delta client/state updates instead of full payload

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient+ClientState.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+ClientState.swift
@@ -1,0 +1,96 @@
+// ABOUTME: client/state reporting for SendspinClient, including delta computation
+// ABOUTME: Tracks the last-sent state and emits only changed fields per spec
+
+import Foundation
+
+// MARK: - client/state snapshots
+
+extension SendspinClient {
+    /// Immutable snapshot of the client state reported to the server, used to
+    /// compute deltas. `player` is `nil` when the player role is inactive.
+    struct SentClientState: Equatable {
+        var state: ClientOperationalState
+        var player: SentPlayerState?
+    }
+
+    /// Player-role portion of a ``SentClientState`` snapshot. Every field is
+    /// always present here; which fields actually go on the wire is decided by
+    /// the delta computation in ``clientStateDelta(from:to:)``.
+    struct SentPlayerState: Equatable {
+        var volume: Int
+        var muted: Bool
+        var staticDelayMs: Int
+        var supportedCommands: [PlayerCommand]
+    }
+}
+
+// MARK: - Sending client/state
+
+extension SendspinClient {
+    /// Player commands whose availability can change at runtime. Per spec this
+    /// is currently only `set_static_delay`.
+    private static let playerSupportedCommands: [PlayerCommand] = [.setStaticDelay]
+
+    /// Send the current client state to the server.
+    ///
+    /// The first send after `server/hello` is the full payload; subsequent
+    /// sends include only fields that changed since the last successful send,
+    /// which the server merges into its existing state. A send that would carry
+    /// no changes is suppressed. The last-sent snapshot is updated only after a
+    /// successful transport send, so a failed send (e.g. the rollback path in
+    /// ``transitionOperationalState(to:)``) leaves delta tracking consistent.
+    func sendClientState() async throws {
+        guard let transport else {
+            throw SendspinClientError.notConnected
+        }
+
+        let current = currentClientStateSnapshot()
+        guard let payload = try Self.clientStateDelta(from: lastSentClientState, to: current) else {
+            return
+        }
+
+        try await transport.send(ClientStateMessage(payload: payload))
+        lastSentClientState = current
+    }
+
+    private func currentClientStateSnapshot() -> SentClientState {
+        let player = roles.contains(.playerV1)
+            ? SentPlayerState(
+                volume: currentVolume,
+                muted: currentMuted,
+                staticDelayMs: staticDelayMs,
+                supportedCommands: Self.playerSupportedCommands
+            )
+            : nil
+        return SentClientState(state: clientOperationalState, player: player)
+    }
+
+    /// Build the `client/state` payload to send, or `nil` if nothing changed.
+    ///
+    /// A `nil` `previous` represents "server has no prior state", so every field
+    /// differs and the result is the full initial payload. Otherwise only changed
+    /// fields are included. The non-optional snapshot values are compared against
+    /// optional previous values, so a `nil` previous naturally reads as "changed".
+    private static func clientStateDelta(
+        from previous: SentClientState?,
+        to current: SentClientState
+    ) throws -> ClientStatePayload? {
+        let previousPlayer = previous?.player
+        let state = current.state != previous?.state ? current.state : nil
+
+        var player: PlayerStateObject?
+        if let p = current.player {
+            let volume = p.volume != previousPlayer?.volume ? p.volume : nil
+            let muted = p.muted != previousPlayer?.muted ? p.muted : nil
+            let delay = p.staticDelayMs != previousPlayer?.staticDelayMs ? p.staticDelayMs : nil
+            let commands = p.supportedCommands != previousPlayer?.supportedCommands ? p.supportedCommands : nil
+            if volume != nil || muted != nil || delay != nil || commands != nil {
+                // Values are pre-clamped on set, so validation never throws here.
+                player = try PlayerStateObject(volume: volume, muted: muted, staticDelayMs: delay, supportedCommands: commands)
+            }
+        }
+
+        guard state != nil || player != nil else { return nil }
+        return ClientStatePayload(state: state, player: player)
+    }
+}

--- a/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
@@ -92,6 +92,9 @@ extension SendspinClient {
         )
         eventsContinuation.yield(.serverConnected(info))
 
+        // Reset delta tracking: a (re)connected server holds no prior client
+        // state, so the post-hello send must be the full baseline, not a delta.
+        lastSentClientState = nil
         // Send initial client state (required by spec)
         try? await sendClientState()
 

--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -58,6 +58,12 @@ public final class SendspinClient {
     /// Cached from `playerConfig?.emitRawAudioEvents` to avoid optional chaining on every audio chunk.
     var shouldEmitRawAudio = false
 
+    /// Snapshot of the last `client/state` successfully sent to the current
+    /// server session, or `nil` before the initial send. Reset on every
+    /// `server/hello` so a (re)connected server receives a full baseline;
+    /// subsequent sends transmit only changed fields (spec delta semantics).
+    var lastSentClientState: SentClientState?
+
     /// Accumulated state (merged from server deltas per spec)
     /// Current track metadata, accumulated from `server/state` deltas.
     public private(set) var currentMetadata: TrackMetadata?
@@ -425,29 +431,6 @@ public final class SendspinClient {
 
         let payload = buildClientHelloPayload()
         try await transport.send(ClientHelloMessage(payload: payload))
-    }
-
-    func sendClientState() async throws {
-        guard let transport else {
-            throw SendspinClientError.notConnected
-        }
-
-        var playerStateObject: PlayerStateObject?
-        if roles.contains(.playerV1) {
-            // Values are already validated (clamped on set), so this should never throw.
-            playerStateObject = try PlayerStateObject(
-                volume: currentVolume,
-                muted: currentMuted,
-                staticDelayMs: staticDelayMs,
-                supportedCommands: [.setStaticDelay]
-            )
-        }
-
-        let payload = ClientStatePayload(
-            state: clientOperationalState,
-            player: playerStateObject
-        )
-        try await transport.send(ClientStateMessage(payload: payload))
     }
 
     // MARK: - Clock synchronization

--- a/Sources/SendspinKit/Models/SendspinMessage.swift
+++ b/Sources/SendspinKit/Models/SendspinMessage.swift
@@ -231,15 +231,20 @@ struct ClientStatePayload: Codable, Equatable {
 }
 
 /// Player state object within client/state message.
-/// Per spec: volume/muted are optional (only if supported), but static_delay_ms is always required.
+///
+/// Every field is optional so this type can express both the initial full
+/// state and subsequent deltas. Per spec, the initial `client/state` after
+/// `server/hello` includes `static_delay_ms`; later delta updates omit any
+/// field that has not changed (the server merges them into existing state).
 struct PlayerStateObject: Codable, Equatable {
     /// Volume level (0-100), only if 'volume' is in supported_commands from player@v1_support
     let volume: Int?
     /// Mute state, only if 'mute' is in supported_commands from player@v1_support
     let muted: Bool?
-    /// Static delay in milliseconds (0-5000), always required for players.
-    /// Compensates for delay beyond the audio port (external speakers, amplifiers).
-    let staticDelayMs: Int
+    /// Static delay in milliseconds (0-5000). Present in the initial full state;
+    /// omitted from a delta when unchanged. Compensates for delay beyond the
+    /// audio port (external speakers, amplifiers).
+    let staticDelayMs: Int?
     /// Supported commands that can change at runtime (e.g. when audio output changes).
     /// Per spec, currently only `set_static_delay` is valid here.
     let supportedCommands: [PlayerCommand]?
@@ -251,17 +256,17 @@ struct PlayerStateObject: Codable, Equatable {
         case supportedCommands = "supported_commands"
     }
 
-    /// Validates volume and static delay ranges.
-    private static func validate(volume: Int?, staticDelayMs: Int) throws(ConfigurationError) {
+    /// Validates volume and static delay ranges when present.
+    private static func validate(volume: Int?, staticDelayMs: Int?) throws(ConfigurationError) {
         if let vol = volume {
             guard vol >= 0, vol <= 100 else { throw .volumeOutOfRange(vol) }
         }
-        guard staticDelayMs >= 0, staticDelayMs <= 5_000 else {
-            throw .staticDelayOutOfRange(staticDelayMs)
+        if let delay = staticDelayMs {
+            guard delay >= 0, delay <= 5_000 else { throw .staticDelayOutOfRange(delay) }
         }
     }
 
-    init(volume: Int? = nil, muted: Bool? = nil, staticDelayMs: Int = 0, supportedCommands: [PlayerCommand]? = nil) throws(ConfigurationError) {
+    init(volume: Int? = nil, muted: Bool? = nil, staticDelayMs: Int? = nil, supportedCommands: [PlayerCommand]? = nil) throws(ConfigurationError) {
         try Self.validate(volume: volume, staticDelayMs: staticDelayMs)
         self.volume = volume
         self.muted = muted
@@ -273,7 +278,7 @@ struct PlayerStateObject: Codable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let volume = try container.decodeIfPresent(Int.self, forKey: .volume)
         let muted = try container.decodeIfPresent(Bool.self, forKey: .muted)
-        let staticDelayMs = try container.decode(Int.self, forKey: .staticDelayMs)
+        let staticDelayMs = try container.decodeIfPresent(Int.self, forKey: .staticDelayMs)
         let supportedCommands = try container.decodeIfPresent([PlayerCommand].self, forKey: .supportedCommands)
 
         do {

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -15,7 +15,7 @@ private let testServerId = "test-server"
 // MARK: - Test helpers
 
 /// Encode a server/hello message using the actual Codable types.
-private func serverHelloJSON(
+func serverHelloJSON(
     serverId: String = testServerId,
     name: String = "Test Server",
     version: Int = 1,
@@ -75,7 +75,7 @@ private func setStaticDelayCommandJSON(_ delayMs: Int) throws -> String {
 
 /// Create a SendspinClient configured for testing with both player and controller roles.
 @MainActor
-private func makeTestClient(
+func makeTestClient(
     roles: Set<VersionedRole> = [.playerV1, .controllerV1],
     persistenceProvider: (any SendspinPersistenceProvider)? = nil
 ) throws -> SendspinClient {
@@ -120,7 +120,7 @@ private actor MockPersistenceProvider: SendspinPersistenceProvider {
 
 /// Poll `condition` until it returns `true` or the deadline passes.
 /// Returns the final evaluation so callers can assert positively or negatively.
-private func waitUntil(
+func waitUntil(
     timeout: Duration = .seconds(2),
     _ condition: @Sendable () async -> Bool
 ) async -> Bool {
@@ -144,7 +144,7 @@ private func waitUntil(
 /// detached; `handleServerHello` doesn't await it). The 3s timeout accommodates
 /// CI scheduling jitter.
 @MainActor
-private func connectClient(
+func connectClient(
     _ client: SendspinClient,
     activeRoles: [VersionedRole] = [.playerV1, .controllerV1],
     connectionReason: ConnectionReason = .discovery

--- a/Tests/SendspinKitTests/Integration/ClientStateDeltaTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientStateDeltaTests.swift
@@ -1,0 +1,108 @@
+// ABOUTME: Tests that client/state is sent as deltas after the initial full payload
+// ABOUTME: Covers issue #19 — only changed fields go on the wire; the server merges them
+
+import Foundation
+@testable import SendspinKit
+import Testing
+
+/// Decode every `client/state` payload sent after `offset`, filtering on the
+/// JSON `type` field. Necessary because `ClientStatePayload`'s fields are all
+/// optional, so other message types decode "successfully" as an empty payload.
+private func clientStatePayloads(from mock: MockTransport, after offset: Int = 0) async -> [ClientStatePayload] {
+    let messages = await mock.sentTextMessages
+    return messages.dropFirst(offset).compactMap { data -> ClientStatePayload? in
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              object["type"] as? String == "client/state" else { return nil }
+        return try? JSONDecoder().decode(ClientStateMessage.self, from: data).payload
+    }
+}
+
+@MainActor
+struct ClientStateDeltaTests {
+    @Test
+    func initialSendIsFullPayload() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        let initial = try #require(
+            await clientStatePayloads(from: mock).first,
+            "Expected an initial client/state after server/hello"
+        )
+
+        #expect(initial.state == .synchronized)
+        let player = try #require(initial.player, "Initial state must include the full player object")
+        #expect(player.volume == client.currentVolume)
+        #expect(player.muted == client.currentMuted)
+        #expect(player.staticDelayMs == client.staticDelayMs)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func subsequentChangeSendsOnlyChangedFields() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        let countBefore = await mock.sentTextMessages.count
+        let newVolume = client.currentVolume == 100 ? 42 : 100
+        try await client.setVolume(newVolume)
+
+        let delta = try #require(
+            await clientStatePayloads(from: mock, after: countBefore).last,
+            "Expected a client/state delta after setVolume"
+        )
+
+        // Only the changed field is present; unchanged fields are omitted.
+        #expect(delta.state == nil)
+        #expect(delta.player?.volume == newVolume)
+        #expect(delta.player?.muted == nil)
+        #expect(delta.player?.staticDelayMs == nil)
+        #expect(delta.player?.supportedCommands == nil)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func unchangedUpdateIsSuppressed() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        let countBefore = await mock.sentTextMessages.count
+        // Re-set the current values: nothing changed, so nothing should be sent.
+        try await client.setVolume(client.currentVolume)
+        try await client.setMute(client.currentMuted)
+
+        let deltas = await clientStatePayloads(from: mock, after: countBefore)
+        #expect(deltas.isEmpty, "A no-op state update must not send a client/state message")
+
+        await client.disconnect()
+    }
+
+    @Test
+    func reconnectResendsFullBaseline() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        let newVolume = client.currentVolume == 100 ? 42 : 100
+        try await client.setVolume(newVolume)
+
+        // A fresh server/hello means the server holds no prior state, so the
+        // next send must be the full baseline — even though nothing changed.
+        let countBefore = await mock.sentTextMessages.count
+        try await mock.injectText(serverHelloJSON())
+        let appeared = await waitUntil {
+            await !clientStatePayloads(from: mock, after: countBefore).isEmpty
+        }
+        #expect(appeared, "Expected a client/state after re-hello")
+
+        let baseline = try #require(
+            await clientStatePayloads(from: mock, after: countBefore).first,
+            "Expected a full client/state after re-hello"
+        )
+        #expect(baseline.state == .synchronized)
+        #expect(baseline.player?.volume == newVolume)
+        #expect(baseline.player?.staticDelayMs == client.staticDelayMs)
+
+        await client.disconnect()
+    }
+}


### PR DESCRIPTION
Per spec, the initial client/state after server/hello is the full payload; subsequent updates should include only the fields that changed, which the server merges into its existing state (issue #19). Until now every change re-sent the complete ClientStatePayload.

SendspinClient now tracks the last successfully-sent state and emits only changed fields, suppressing no-op sends entirely. The snapshot is reset on every server/hello so a (re)connected server always receives a full baseline, and it is updated only after a successful transport send so the transitionOperationalState rollback path stays consistent.

To make a true delta expressible, PlayerStateObject.staticDelayMs becomes optional (it was the one always-encoded field) so a volume-only delta can omit it. The client/state reporting logic moves into a dedicated SendspinClient+ClientState.swift extension to keep the orchestrator under the file-length limit and give the delta computation a cohesive home.

Verified against the aiosendspin server via the conformance harness: PCM (client- and server-initiated), metadata, and artwork scenarios pass, confirming the server accepts both the initial full state and deltas.

Closes #19