### PR TITLE
fix(transport): dispatch incoming frames in wire order

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
@@ -380,7 +380,12 @@ extension SendspinClient {
         // and also surfaced as an event for observation (e.g. UI).
         if message.payload.playbackState == .playing, let serverId = currentServerId {
             eventsContinuation.yield(.lastPlayedServerChanged(serverId: serverId))
-            await persistenceProvider?.saveLastPlayedServerId(serverId)
+            // Fire-and-forget: the host provider may do slow I/O, and frames are
+            // now dispatched on a single ordered task — awaiting here would stall
+            // audio-frame intake behind a storage write.
+            if let persistenceProvider {
+                Task { await persistenceProvider.saveLastPlayedServerId(serverId) }
+            }
         }
 
         // Per spec: "Contains delta updates with only the changed fields.

--- a/Sources/SendspinKit/Client/SendspinClient+MultiServer.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MultiServer.swift
@@ -97,11 +97,11 @@ extension SendspinClient {
 
         return try await withThrowingTaskGroup(of: ServerHelloMessage?.self) { group in
             group.addTask {
-                for await text in transport.textMessages {
-                    if let hello = Self.decodeServerHello(text) {
-                        return hello
-                    }
+                for await frame in transport.frames {
                     // server/hello is the first message per spec; ignore anything before it.
+                    guard case let .text(text) = frame,
+                          let hello = Self.decodeServerHello(text) else { continue }
+                    return hello
                 }
                 return nil // stream ended without a server/hello
             }

--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -302,11 +302,10 @@ public final class SendspinClient {
             try await sendClientHello()
         }
 
-        let textStream = transport.textMessages
-        let binaryStream = transport.binaryMessages
+        let frames = transport.frames
 
         messageLoopTask = Task.detached { [weak self] in
-            await self?.runMessageLoop(textStream: textStream, binaryStream: binaryStream)
+            await self?.runMessageLoop(frames: frames)
         }
 
         // Clock sync starts after server/hello is received (in handleServerHello)
@@ -476,27 +475,24 @@ public final class SendspinClient {
 
     // MARK: - Message loop
 
-    private nonisolated func runMessageLoop(
-        textStream: AsyncStream<String>,
-        binaryStream: AsyncStream<Data>
-    ) async {
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask { [weak self] in
-                guard let self else { return }
-                for await text in textStream {
-                    await handleTextMessage(text)
-                }
-            }
-
-            group.addTask { [weak self] in
-                guard let self else { return }
-                for await data in binaryStream {
-                    await handleBinaryMessage(data)
-                }
+    /// Dispatch incoming frames in wire order on a single task.
+    ///
+    /// Text and binary frames share one ordered stream so a control message can
+    /// never overtake the audio frames that preceded it (e.g. `stream/end` must
+    /// be handled only after the audio chunks the server sent before it). Audio
+    /// *output* is decoupled on ``runSchedulerOutput()``, so serial frame
+    /// dispatch here does not gate playback.
+    private nonisolated func runMessageLoop(frames: AsyncStream<TransportFrame>) async {
+        for await frame in frames {
+            switch frame {
+            case let .text(text):
+                await handleTextMessage(text)
+            case let .binary(data):
+                await handleBinaryMessage(data)
             }
         }
 
-        // Both streams ended — connection was lost (not an explicit disconnect,
+        // The frame stream ended — connection was lost (not an explicit disconnect,
         // which cancels this task before streams end naturally)
         await MainActor.run { [weak self] in
             guard let self else { return }

--- a/Sources/SendspinKit/Transport/NWWebSocketTransport.swift
+++ b/Sources/SendspinKit/Transport/NWWebSocketTransport.swift
@@ -9,8 +9,10 @@ import os
 /// Created by `ClientAdvertiser` when a server connects to the client's WebSocket endpoint.
 actor NWWebSocketTransport: SendspinTransport {
     private var connection: NWConnection?
-    private let textContinuation: AsyncStream<String>.Continuation
-    private let binaryContinuation: AsyncStream<Data>.Continuation
+    /// `nonisolated` so the receive callback can yield frames directly in
+    /// arrival order. Hopping onto the actor via a per-frame `Task` would let
+    /// independent tasks run out of order and shuffle frames (audio included).
+    private nonisolated let frameContinuation: AsyncStream<TransportFrame>.Continuation
     /// Confined to actor isolation — do not pass across isolation boundaries.
     private let encoder = SendspinEncoding.makeEncoder()
 
@@ -19,20 +21,16 @@ actor NWWebSocketTransport: SendspinTransport {
     /// so we can suppress the noisy (but expected) post-close receive error log.
     private var closeReceived = false
 
-    nonisolated let textMessages: AsyncStream<String>
-    nonisolated let binaryMessages: AsyncStream<Data>
+    nonisolated let frames: AsyncStream<TransportFrame>
 
     /// Initialize with an already-established NWConnection that has WebSocket framing.
     /// The connection should be in the `.ready` state.
     init(connection: NWConnection) {
         self.connection = connection
 
-        let (textStream, textCont) = AsyncStream<String>.makeStream()
-        let (binaryStream, binaryCont) = AsyncStream<Data>.makeStream()
-        textMessages = textStream
-        binaryMessages = binaryStream
-        textContinuation = textCont
-        binaryContinuation = binaryCont
+        let (frameStream, frameCont) = AsyncStream<TransportFrame>.makeStream()
+        frames = frameStream
+        frameContinuation = frameCont
     }
 
     /// Start receiving messages from the connection.
@@ -104,8 +102,7 @@ actor NWWebSocketTransport: SendspinTransport {
     func disconnect() async {
         connection?.cancel()
         connection = nil
-        textContinuation.finish()
-        binaryContinuation.finish()
+        frameContinuation.finish()
     }
 
     // MARK: - Private
@@ -132,11 +129,11 @@ actor NWWebSocketTransport: SendspinTransport {
                 switch metadata.opcode {
                 case .text:
                     if let data = content, let text = String(data: data, encoding: .utf8) {
-                        Task { await self.yieldText(text) }
+                        frameContinuation.yield(.text(text))
                     }
                 case .binary:
                     if let data = content {
-                        Task { await self.yieldBinary(data) }
+                        frameContinuation.yield(.binary(data))
                     }
                 case .close:
                     // Note the close but keep receiving — data frames may be queued
@@ -152,14 +149,6 @@ actor NWWebSocketTransport: SendspinTransport {
             // Continue receiving
             receiveNext(on: connection)
         }
-    }
-
-    private func yieldText(_ text: String) {
-        textContinuation.yield(text)
-    }
-
-    private func yieldBinary(_ data: Data) {
-        binaryContinuation.yield(data)
     }
 
     /// Called on WebSocket close frame. We note it but do NOT finish the stream
@@ -181,7 +170,6 @@ actor NWWebSocketTransport: SendspinTransport {
 
     /// Called when the receive loop terminates (error or connection gone).
     private func finishStreams() {
-        textContinuation.finish()
-        binaryContinuation.finish()
+        frameContinuation.finish()
     }
 }

--- a/Sources/SendspinKit/Transport/SendspinTransport.swift
+++ b/Sources/SendspinKit/Transport/SendspinTransport.swift
@@ -3,15 +3,30 @@
 
 import Foundation
 
+/// A single incoming WebSocket frame, tagged by payload kind.
+///
+/// Transports surface text and binary frames through one ordered stream so the
+/// exact wire order is preserved end-to-end (see ``SendspinTransport/frames``).
+public enum TransportFrame: Sendable {
+    /// Text frame (a JSON control message).
+    case text(String)
+    /// Binary frame (audio, artwork, or visualization data).
+    case binary(Data)
+}
+
 /// Protocol for WebSocket transports used by SendspinClient.
 /// Both outbound (client connects to server) and inbound (server connects to client)
 /// connections conform to this protocol.
 public protocol SendspinTransport: Actor, Sendable {
-    /// Stream of incoming text messages (JSON payloads)
-    nonisolated var textMessages: AsyncStream<String> { get }
-
-    /// Stream of incoming binary messages (audio, artwork, visualization)
-    nonisolated var binaryMessages: AsyncStream<Data> { get }
+    /// Ordered stream of incoming frames, in the exact order the server sent
+    /// them on the wire.
+    ///
+    /// - Important: Text and binary frames share one stream on purpose. Stream
+    ///   lifecycle control messages (e.g. `stream/end`, which stops output and
+    ///   clears buffers on receipt) must be processed *after* the audio frames
+    ///   that preceded them. Splitting text and binary into separately-drained
+    ///   streams would let a control message overtake still-unprocessed audio.
+    nonisolated var frames: AsyncStream<TransportFrame> { get }
 
     /// Whether the transport is currently connected
     var isConnected: Bool { get }

--- a/Sources/SendspinKit/Transport/WebSocketTransport.swift
+++ b/Sources/SendspinKit/Transport/WebSocketTransport.swift
@@ -20,13 +20,11 @@ private struct DelegateState {
 /// briefly (just setting a bool or consuming a continuation), so contention
 /// is negligible.
 private final class StarscreamDelegate: WebSocketDelegate, Sendable {
-    let textContinuation: AsyncStream<String>.Continuation
-    let binaryContinuation: AsyncStream<Data>.Continuation
+    let frameContinuation: AsyncStream<TransportFrame>.Continuation
     let state = OSAllocatedUnfairLock(initialState: DelegateState())
 
-    init(textContinuation: AsyncStream<String>.Continuation, binaryContinuation: AsyncStream<Data>.Continuation) {
-        self.textContinuation = textContinuation
-        self.binaryContinuation = binaryContinuation
+    init(frameContinuation: AsyncStream<TransportFrame>.Continuation) {
+        self.frameContinuation = frameContinuation
     }
 
     /// Whether the WebSocket is connected. Thread-safe read.
@@ -55,10 +53,10 @@ private final class StarscreamDelegate: WebSocketDelegate, Sendable {
             handleDisconnection(error: error ?? TransportError.connectionFailed)
 
         case let .text(string):
-            textContinuation.yield(string)
+            frameContinuation.yield(.text(string))
 
         case let .binary(data):
-            binaryContinuation.yield(data)
+            frameContinuation.yield(.binary(data))
 
         case .ping, .pong, .viabilityChanged, .reconnectSuggested:
             break
@@ -83,8 +81,7 @@ private final class StarscreamDelegate: WebSocketDelegate, Sendable {
             return cont
         }
         continuation?.resume(throwing: error)
-        textContinuation.finish()
-        binaryContinuation.finish()
+        frameContinuation.finish()
     }
 }
 
@@ -97,22 +94,15 @@ actor WebSocketTransport: SendspinTransport {
     /// Confined to actor isolation — do not pass across isolation boundaries.
     private let encoder = SendspinEncoding.makeEncoder()
 
-    /// Stream of incoming text messages (JSON)
-    nonisolated let textMessages: AsyncStream<String>
-
-    /// Stream of incoming binary messages (audio, artwork, etc.)
-    nonisolated let binaryMessages: AsyncStream<Data>
+    /// Ordered stream of incoming frames (text + binary), in wire order.
+    nonisolated let frames: AsyncStream<TransportFrame>
 
     init(url: URL) {
         self.url = url
 
-        // Create streams and pass continuations to delegate
-        let (textStream, textCont) = AsyncStream<String>.makeStream()
-        let (binaryStream, binaryCont) = AsyncStream<Data>.makeStream()
-
-        textMessages = textStream
-        binaryMessages = binaryStream
-        delegate = StarscreamDelegate(textContinuation: textCont, binaryContinuation: binaryCont)
+        let (frameStream, frameCont) = AsyncStream<TransportFrame>.makeStream()
+        frames = frameStream
+        delegate = StarscreamDelegate(frameContinuation: frameCont)
     }
 
     /// Connect to the WebSocket server

--- a/Tests/SendspinKitTests/Helpers/MockTransport.swift
+++ b/Tests/SendspinKitTests/Helpers/MockTransport.swift
@@ -10,11 +10,9 @@ import Foundation
 /// Inspect client-sent messages via `sentTextMessages` and `sentBinaryMessages`.
 /// Simulate failures via `setShouldFailOnSend(_:)`.
 actor MockTransport: SendspinTransport {
-    nonisolated let textMessages: AsyncStream<String>
-    nonisolated let binaryMessages: AsyncStream<Data>
+    nonisolated let frames: AsyncStream<TransportFrame>
 
-    private let textContinuation: AsyncStream<String>.Continuation
-    private let binaryContinuation: AsyncStream<Data>.Continuation
+    private let frameContinuation: AsyncStream<TransportFrame>.Continuation
 
     /// JSON-encoded messages sent by the client, captured as raw Data.
     private(set) var sentTextMessages: [Data] = []
@@ -31,8 +29,7 @@ actor MockTransport: SendspinTransport {
     private let encoder = SendspinEncoding.makeEncoder()
 
     init() {
-        (textMessages, textContinuation) = AsyncStream.makeStream()
-        (binaryMessages, binaryContinuation) = AsyncStream.makeStream()
+        (frames, frameContinuation) = AsyncStream.makeStream()
     }
 
     // MARK: - SendspinTransport conformance
@@ -63,20 +60,19 @@ actor MockTransport: SendspinTransport {
 
     /// Inject a JSON text message as if the server sent it.
     func injectText(_ json: String) {
-        textContinuation.yield(json)
+        frameContinuation.yield(.text(json))
     }
 
     /// Inject raw binary data as if the server sent it.
     func injectBinary(_ data: Data) {
-        binaryContinuation.yield(data)
+        frameContinuation.yield(.binary(data))
     }
 
-    /// Finish both streams (simulates connection close without changing `isConnected`).
+    /// Finish the frame stream (simulates connection close without changing `isConnected`).
     /// `disconnect()` delegates here for the stream teardown portion.
     /// Safe to call multiple times — `AsyncStream.Continuation.finish()` is idempotent.
     func finishStreams() {
-        textContinuation.finish()
-        binaryContinuation.finish()
+        frameContinuation.finish()
     }
 
     /// Enable or disable simulated send failures.

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -167,7 +167,7 @@ func connectClient(
 
 /// Poll until the client reaches the expected connection state.
 @MainActor
-private func waitForState(
+func waitForState(
     _ client: SendspinClient,
     expected: ConnectionState,
     timeout: Duration
@@ -597,98 +597,6 @@ struct ClientIntegrationTests {
         #expect(info.hasRole(.playerV1) == true)
         #expect(info.hasRole(.controllerV1) == true)
         #expect(info.hasRole(.artworkV1) == false)
-
-        await client.disconnect()
-    }
-
-    // MARK: rawAudioChunk emitted for chunks arriving before stream/start
-
-    @Test
-    func rawAudioChunks_emittedEvenWhenArrivingBeforeStreamStart() async throws {
-        // Regression test: binary and text messages are consumed by parallel tasks
-        // in the message loop. If the binary task processes audio chunks before the
-        // text task processes stream/start, shouldEmitRawAudio must already be true
-        // (set at connection setup, not deferred to handleStreamStart).
-        let client = try SendspinClient(
-            clientId: "test-client",
-            name: "Test Client",
-            roles: [.playerV1],
-            playerConfig: PlayerConfiguration(
-                bufferCapacity: 1_024,
-                supportedFormats: [
-                    AudioFormatSpec(codec: .pcm, channels: 1, sampleRate: 8_000, bitDepth: 16)
-                ],
-                emitRawAudioEvents: true
-            )
-        )
-
-        let mock = MockTransport()
-        try await client.acceptConnection(mock)
-
-        // Inject server/hello so the client reaches .connected state
-        try await mock.injectText(serverHelloJSON())
-        try await waitForState(client, expected: .connected, timeout: .seconds(3))
-
-        // Inject binary audio chunks BEFORE stream/start text message.
-        // This reproduces the race: the binary task may process these before
-        // the text task gets to stream/start.
-        let pcmSamples = Data(repeating: 0x7F, count: 400) // 200 samples × 16-bit
-        let timestamp: Int64 = 1_000_000
-        let chunkCount = 3
-        for i in 0 ..< chunkCount {
-            var frame = Data()
-            frame.append(BinaryMessageType.audioChunk.rawValue)
-            var ts = (timestamp + Int64(i) * 25_000).bigEndian
-            frame.append(Data(bytes: &ts, count: 8))
-            frame.append(pcmSamples)
-            await mock.injectBinary(frame)
-        }
-
-        // Now inject stream/start — this is when handleStreamStart runs, but
-        // the audio chunks above may already have been processed by then.
-        let streamStart = StreamStartMessage(
-            payload: StreamStartPayload(
-                player: StreamStartPlayer(
-                    codec: "pcm",
-                    sampleRate: 8_000,
-                    channels: 1,
-                    bitDepth: 16,
-                    codecHeader: nil
-                ),
-                artwork: nil,
-                visualizer: nil
-            )
-        )
-        let streamStartData = try JSONEncoder().encode(streamStart)
-        let streamStartJSON = try #require(String(data: streamStartData, encoding: .utf8))
-        await mock.injectText(streamStartJSON)
-
-        // Collect rawAudioChunk events
-        let stream = client.events
-        let collected = await withTaskGroup(of: Int.self) { group in
-            group.addTask {
-                var count = 0
-                for await event in stream {
-                    if case .rawAudioChunk = event {
-                        count += 1
-                    }
-                    // Stop after we've seen stream start + all chunks, or timeout
-                    if count >= chunkCount { break }
-                }
-                return count
-            }
-            group.addTask {
-                try? await Task.sleep(for: .seconds(3))
-                return -1 // sentinel for timeout
-            }
-            for await result in group {
-                group.cancelAll()
-                return result
-            }
-            return 0
-        }
-
-        #expect(collected == chunkCount, "Expected \(chunkCount) rawAudioChunk events but got \(collected)")
 
         await client.disconnect()
     }

--- a/Tests/SendspinKitTests/Integration/FrameOrderingTests.swift
+++ b/Tests/SendspinKitTests/Integration/FrameOrderingTests.swift
@@ -1,0 +1,151 @@
+// ABOUTME: Verifies incoming frames are dispatched in wire order
+// ABOUTME: Audio chunks and stream lifecycle messages must not reorder relative to each other
+
+import Foundation
+@testable import SendspinKit
+import Testing
+
+/// Build a binary `audio chunk` frame (type byte + big-endian timestamp + PCM bytes).
+private func audioChunkFrame(index: Int, baseTimestamp: Int64 = 1_000_000) -> Data {
+    var frame = Data()
+    frame.append(BinaryMessageType.audioChunk.rawValue)
+    var timestamp = (baseTimestamp + Int64(index) * 25_000).bigEndian
+    frame.append(Data(bytes: &timestamp, count: 8))
+    frame.append(Data(repeating: 0x7F, count: 400)) // 200 samples × 16-bit
+    return frame
+}
+
+private func streamStartPCMJSON() throws -> String {
+    let message = StreamStartMessage(
+        payload: StreamStartPayload(
+            player: StreamStartPlayer(codec: "pcm", sampleRate: 8_000, channels: 1, bitDepth: 16, codecHeader: nil),
+            artwork: nil,
+            visualizer: nil
+        )
+    )
+    return try #require(String(data: JSONEncoder().encode(message), encoding: .utf8))
+}
+
+@MainActor
+struct FrameOrderingTests {
+    /// A headless player that surfaces raw audio frames.
+    private func makePlayerClient() throws -> SendspinClient {
+        try SendspinClient(
+            clientId: "test-client",
+            name: "Test Client",
+            roles: [.playerV1],
+            playerConfig: PlayerConfiguration(
+                bufferCapacity: 65_536,
+                supportedFormats: [
+                    AudioFormatSpec(codec: .pcm, channels: 1, sampleRate: 8_000, bitDepth: 16)
+                ],
+                volumeMode: .none, // headless — skip real audio-output setup
+                emitRawAudioEvents: true
+            )
+        )
+    }
+
+    @Test
+    func rawAudioChunks_emittedEvenWhenArrivingBeforeStreamStart() async throws {
+        // Frames are dispatched in wire order on a single task, so audio chunks that
+        // arrive before stream/start are processed before it. shouldEmitRawAudio must
+        // therefore already be true at connection setup (not deferred to
+        // handleStreamStart) or these chunks emit no raw events.
+        let client = try makePlayerClient()
+        let mock = MockTransport()
+        try await client.acceptConnection(mock)
+        try await mock.injectText(serverHelloJSON())
+        try await waitForState(client, expected: .connected, timeout: .seconds(3))
+
+        // Inject audio chunks BEFORE stream/start.
+        let chunkCount = 3
+        for i in 0 ..< chunkCount {
+            await mock.injectBinary(audioChunkFrame(index: i))
+        }
+        try await mock.injectText(streamStartPCMJSON())
+
+        let stream = client.events
+        let collected = await withTaskGroup(of: Int.self) { group in
+            group.addTask {
+                var count = 0
+                for await event in stream {
+                    if case .rawAudioChunk = event { count += 1 }
+                    if count >= chunkCount { break }
+                }
+                return count
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(3))
+                return -1 // sentinel for timeout
+            }
+            for await result in group {
+                group.cancelAll()
+                return result
+            }
+            return 0
+        }
+
+        #expect(collected == chunkCount, "Expected \(chunkCount) rawAudioChunk events but got \(collected)")
+
+        await client.disconnect()
+    }
+
+    @Test
+    func streamEnd_isDeliveredAfterAllPrecedingAudioChunks() async throws {
+        // The server sends all audio chunks then stream/end, in that wire order.
+        // stream/end stops output and clears buffers on receipt, so it must NEVER
+        // be surfaced before the audio frames the server sent before it. With
+        // the old split text/binary dispatch, the text task could yield
+        // streamEnded while the binary task was still draining chunks,
+        // truncating the stream. A single ordered frame loop guarantees every
+        // rawAudioChunk precedes streamEnded.
+        let client = try makePlayerClient()
+        let mock = MockTransport()
+        try await client.acceptConnection(mock)
+        try await mock.injectText(serverHelloJSON())
+        try await waitForState(client, expected: .connected, timeout: .seconds(3))
+
+        // stream/start, then many audio chunks, then stream/end — exact wire order.
+        // Enough chunks to expose the race: the old binary task lagged the text task
+        // by dozens of chunks before stream/end overtook them.
+        try await mock.injectText(streamStartPCMJSON())
+        let chunkCount = 64
+        for i in 0 ..< chunkCount {
+            await mock.injectBinary(audioChunkFrame(index: i))
+        }
+        try await mock.injectText(#require(String(data: JSONEncoder().encode(StreamEndMessage()), encoding: .utf8)))
+
+        // Count rawAudioChunk events seen before the streamEnded event.
+        let stream = client.events
+        let outcome: (chunksBeforeEnd: Int, sawEnd: Bool) = await withTaskGroup(of: (Int, Bool)?.self) { group in
+            group.addTask {
+                var chunks = 0
+                for await event in stream {
+                    switch event {
+                    case .rawAudioChunk: chunks += 1
+                    case .streamEnded: return (chunks, true)
+                    default: break
+                    }
+                }
+                return (chunks, false)
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(10))
+                return nil
+            }
+            for await result in group {
+                group.cancelAll()
+                return result ?? (-1, false)
+            }
+            return (0, false)
+        }
+
+        #expect(outcome.sawEnd, "Expected a streamEnded event")
+        #expect(
+            outcome.chunksBeforeEnd == chunkCount,
+            "All \(chunkCount) rawAudioChunk events must precede streamEnded; saw \(outcome.chunksBeforeEnd)"
+        )
+
+        await client.disconnect()
+    }
+}

--- a/Tests/SendspinKitTests/Transport/WebSocketTransportTests.swift
+++ b/Tests/SendspinKitTests/Transport/WebSocketTransportTests.swift
@@ -4,15 +4,12 @@ import Testing
 
 struct WebSocketTransportTests {
     @Test
-    func createsAsyncStreamsForMessages() throws {
+    func createsAsyncStreamForFrames() throws {
         let url = try #require(URL(string: "ws://localhost:8927/sendspin"))
         let transport = WebSocketTransport(url: url)
 
-        // Verify streams exist
-        _ = transport.textMessages.makeAsyncIterator()
-        _ = transport.binaryMessages.makeAsyncIterator()
-
-        // Streams should be ready but have no data yet
+        // Verify the ordered frame stream exists (no data yet).
         // (This is a basic structure test - full WebSocket testing requires mock server)
+        _ = transport.frames.makeAsyncIterator()
     }
 }


### PR DESCRIPTION
The client split the WebSocket into separate text and binary streams drained by two concurrent tasks, discarding the order the server sent frames in. Because handleAudioChunk does per-chunk async work, the binary task lagged the text task, so a `stream/end` (which stops output and clears buffers on receipt) could overtake audio chunks the server sent before it. Against the aiosendspin conformance server this truncated FLAC capture to the first ~8 of 69 chunks roughly half the time. Both reference clients (sendspin-rs, aiosendspin) consume a single wire-ordered loop instead.

Collapse text and binary into one ordered `frames: AsyncStream<TransportFrame>` on SendspinTransport, consumed by a single dispatch loop. Audio output is already decoupled on the scheduler-output task, so serial frame dispatch does not gate playback. The group/update persistence save is now fire-and-forget so a slow host provider can't stall frame intake on the now-single loop.

NWWebSocketTransport additionally stops hopping each frame onto the actor via a per-frame Task (independent tasks could reorder frames, audio included) and yields directly from the ordered receive callback.

Adds FrameOrderingTests covering that every rawAudioChunk is surfaced before streamEnded. Verified end-to-end: FLAC conformance now passes 10/10 (full 69 chunks) where it was ~50% flaky.