### PR TITLE
feat(client): parse repeat/shuffle from controller state

### DIFF
--- a/Examples/ControllerClient/Sources/ControllerClient/ControllerClient.swift
+++ b/Examples/ControllerClient/Sources/ControllerClient/ControllerClient.swift
@@ -165,6 +165,12 @@ struct ControllerClient: AsyncParsableCommand {
             case let .controllerStateUpdated(ctrl):
                 state.currentVolume = ctrl.volume
                 state.isMuted = ctrl.muted
+                if let mode = ctrl.repeatMode {
+                    state.repeatMode = mode
+                }
+                if let shuffle = ctrl.shuffle {
+                    state.isShuffled = shuffle
+                }
                 let supported = ctrl.supportedCommands.map(\.rawValue).sorted().joined(separator: ", ")
                 print("\n[controller] vol=\(ctrl.volume) muted=\(ctrl.muted) commands: \(supported)")
 
@@ -173,12 +179,6 @@ struct ControllerClient: AsyncParsableCommand {
                 let title = metadata.title ?? "Unknown"
                 if let progress = metadata.progress {
                     state.isPlaying = progress.playbackSpeedX1000 != 0
-                }
-                if let mode = metadata.repeatMode {
-                    state.repeatMode = mode
-                }
-                if let shuffle = metadata.shuffle {
-                    state.isShuffled = shuffle
                 }
                 print("\n[now playing] \(artist) - \(title)")
 

--- a/Examples/MetadataClient/Sources/MetadataClient/main.swift
+++ b/Examples/MetadataClient/Sources/MetadataClient/main.swift
@@ -124,12 +124,7 @@ struct MetadataClient: AsyncParsableCommand {
                 if let art = metadata.artworkURL {
                     print("  Artwork URL:  \(art)")
                 }
-                if let mode = metadata.repeatMode {
-                    print("  Repeat:       \(mode.rawValue)")
-                }
-                if let shuffle = metadata.shuffle {
-                    print("  Shuffle:      \(shuffle)")
-                }
+                // Repeat/shuffle now live on the controller role's state, not metadata.
                 // Progress contains a snapshot timestamp — use currentPositionMs(at:)
                 // with client.currentServerTimeMicroseconds() to interpolate live.
                 if let progress = metadata.progress {

--- a/Sources/SendspinKit/Client/ClientTypes.swift
+++ b/Sources/SendspinKit/Client/ClientTypes.swift
@@ -173,8 +173,6 @@ public struct TrackMetadata: Sendable, Hashable {
     /// metadata to external systems or for clients that fetch images themselves.
     public let artworkURL: String?
     public let progress: PlaybackProgress?
-    public let repeatMode: RepeatMode?
-    public let shuffle: Bool?
 }
 
 /// Controller state from the server.
@@ -190,6 +188,10 @@ public struct ControllerState: Sendable, Hashable {
     public let volume: Int
     /// Group mute state (`true` only when all players in the group are muted)
     public let muted: Bool
+    /// Group repeat mode, `nil` if the server has not reported one.
+    public let repeatMode: RepeatMode?
+    /// Group shuffle state, `nil` if the server has not reported one.
+    public let shuffle: Bool?
 }
 
 /// Errors thrown by `SendspinClient` methods.

--- a/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
@@ -173,9 +173,7 @@ extension SendspinClient {
                 track: metadata.track.merge(previous: prev?.track),
                 year: metadata.year.merge(previous: prev?.year),
                 artworkURL: metadata.artworkUrl.merge(previous: prev?.artworkURL),
-                progress: progress,
-                repeatMode: metadata.repeat.merge(previous: prev?.repeatMode),
-                shuffle: metadata.shuffle.merge(previous: prev?.shuffle)
+                progress: progress
             )
             updateMetadata(merged)
             eventsContinuation.yield(.metadataReceived(merged))
@@ -203,7 +201,9 @@ extension SendspinClient {
             let state = ControllerState(
                 supportedCommands: cmds,
                 volume: vol,
-                muted: muted
+                muted: muted,
+                repeatMode: controller.repeat ?? prev?.repeatMode,
+                shuffle: controller.shuffle ?? prev?.shuffle
             )
             updateControllerState(state)
             eventsContinuation.yield(.controllerStateUpdated(state))

--- a/Sources/SendspinKit/Models/SendspinMessage.swift
+++ b/Sources/SendspinKit/Models/SendspinMessage.swift
@@ -344,17 +344,31 @@ struct ServerControllerState: Codable, Equatable {
     let volume: Int?
     /// Group mute state (true only when all players muted)
     let muted: Bool?
+    /// Group repeat mode
+    let `repeat`: RepeatMode?
+    /// Group shuffle state
+    let shuffle: Bool?
 
     enum CodingKeys: String, CodingKey {
         case supportedCommands = "supported_commands"
         case volume
         case muted
+        case `repeat`
+        case shuffle
     }
 
-    init(supportedCommands: [ControllerCommandType]? = nil, volume: Int? = nil, muted: Bool? = nil) {
+    init(
+        supportedCommands: [ControllerCommandType]? = nil,
+        volume: Int? = nil,
+        muted: Bool? = nil,
+        repeat: RepeatMode? = nil,
+        shuffle: Bool? = nil
+    ) {
         self.supportedCommands = supportedCommands
         self.volume = volume
         self.muted = muted
+        self.repeat = `repeat`
+        self.shuffle = shuffle
     }
 }
 
@@ -445,8 +459,6 @@ struct ServerMetadataState: Equatable {
     let year: Nullable<Int>
     let track: Nullable<Int>
     let progress: Nullable<MetadataProgress>
-    let `repeat`: Nullable<RepeatMode>
-    let shuffle: Nullable<Bool>
 
     enum CodingKeys: String, CodingKey {
         case timestamp
@@ -458,15 +470,12 @@ struct ServerMetadataState: Equatable {
         case year
         case track
         case progress
-        case `repeat`
-        case shuffle
     }
 
     init(
         timestamp: Int64? = nil, title: Nullable<String> = .absent, artist: Nullable<String> = .absent,
         albumArtist: Nullable<String> = .absent, album: Nullable<String> = .absent, artworkUrl: Nullable<String> = .absent,
-        year: Nullable<Int> = .absent, track: Nullable<Int> = .absent, progress: Nullable<MetadataProgress> = .absent,
-        repeat: Nullable<RepeatMode> = .absent, shuffle: Nullable<Bool> = .absent
+        year: Nullable<Int> = .absent, track: Nullable<Int> = .absent, progress: Nullable<MetadataProgress> = .absent
     ) {
         self.timestamp = timestamp
         self.title = title
@@ -477,8 +486,6 @@ struct ServerMetadataState: Equatable {
         self.year = year
         self.track = track
         self.progress = progress
-        self.repeat = `repeat`
-        self.shuffle = shuffle
     }
 }
 
@@ -494,8 +501,6 @@ extension ServerMetadataState: Decodable {
         year = container.contains(.year) ? try container.decode(Nullable<Int>.self, forKey: .year) : .absent
         track = container.contains(.track) ? try container.decode(Nullable<Int>.self, forKey: .track) : .absent
         progress = container.contains(.progress) ? try container.decode(Nullable<MetadataProgress>.self, forKey: .progress) : .absent
-        `repeat` = container.contains(.repeat) ? try container.decode(Nullable<RepeatMode>.self, forKey: .repeat) : .absent
-        shuffle = container.contains(.shuffle) ? try container.decode(Nullable<Bool>.self, forKey: .shuffle) : .absent
     }
 }
 
@@ -512,8 +517,6 @@ extension ServerMetadataState: Encodable {
         if !year.isAbsent { try container.encode(year, forKey: .year) }
         if !track.isAbsent { try container.encode(track, forKey: .track) }
         if !progress.isAbsent { try container.encode(progress, forKey: .progress) }
-        if !`repeat`.isAbsent { try container.encode(`repeat`, forKey: .repeat) }
-        if !shuffle.isAbsent { try container.encode(shuffle, forKey: .shuffle) }
     }
 }
 

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -73,6 +73,13 @@ private func setStaticDelayCommandJSON(_ delayMs: Int) throws -> String {
     return String(bytes: data, encoding: .utf8) ?? ""
 }
 
+/// Encode a `server/state` message carrying only a controller object.
+private func serverStateControllerJSON(_ controller: ServerControllerState) throws -> String {
+    let message = ServerStateMessage(payload: ServerStatePayload(controller: controller))
+    let data = try JSONEncoder().encode(message)
+    return String(bytes: data, encoding: .utf8) ?? ""
+}
+
 /// Create a SendspinClient configured for testing with both player and controller roles.
 @MainActor
 func makeTestClient(
@@ -542,6 +549,36 @@ struct ClientIntegrationTests {
         let command = try await lastSentCommand(from: mock, after: countBefore)
         let sent = try #require(command, "Expected a ClientCommandMessage after setShuffle(true)")
         #expect(sent.payload.controller?.command == .shuffle)
+
+        await client.disconnect()
+    }
+
+    // MARK: server-initiated controller repeat/shuffle
+
+    @Test
+    func serverState_controllerRepeatShuffle_surfacesAndMergesOnPublicState() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        try await mock.injectText(serverStateControllerJSON(ServerControllerState(
+            supportedCommands: [.repeatAll, .shuffle], volume: 50, muted: false,
+            repeat: .all, shuffle: true
+        )))
+
+        let sawValues = await waitUntil {
+            let state = await MainActor.run { client.currentControllerState }
+            return state?.repeatMode == .all && state?.shuffle == true
+        }
+        #expect(sawValues, "Controller repeat/shuffle must surface on the public state")
+
+        // A later delta that omits repeat/shuffle must preserve the prior values.
+        try await mock.injectText(serverStateControllerJSON(ServerControllerState(volume: 60)))
+
+        let preserved = await waitUntil {
+            let state = await MainActor.run { client.currentControllerState }
+            return state?.volume == 60 && state?.repeatMode == .all && state?.shuffle == true
+        }
+        #expect(preserved, "Absent repeat/shuffle in a delta must keep previous values")
 
         await client.disconnect()
     }

--- a/Tests/SendspinKitTests/Models/MessageEncodingTests.swift
+++ b/Tests/SendspinKitTests/Models/MessageEncodingTests.swift
@@ -205,7 +205,7 @@ struct MessageEncodingTests {
                     "timestamp": 12345678,
                     "title": null, "artist": null, "album": null,
                     "album_artist": null, "artwork_url": null, "year": null,
-                    "track": null, "progress": null, "repeat": null, "shuffle": null
+                    "track": null, "progress": null
                 }
             }
         }
@@ -240,6 +240,29 @@ struct MessageEncodingTests {
         #expect(metadata.album.merge(previous: "Previous Album") == "Previous Album")
         #expect(metadata.year.merge(previous: 2_024) == 2_024)
         // Absent with no previous should remain nil
-        #expect(metadata.shuffle.merge(previous: nil) == nil)
+        #expect(metadata.track.merge(previous: nil) == nil)
+    }
+
+    @Test
+    func serverState_decodesControllerRepeatAndShuffle() throws {
+        // Per spec, repeat/shuffle live on the controller object, not metadata.
+        let json = """
+        {
+            "type": "server/state",
+            "payload": {
+                "controller": {
+                    "supported_commands": ["repeat_all", "shuffle"],
+                    "volume": 50, "muted": false,
+                    "repeat": "all", "shuffle": true
+                }
+            }
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let message = try JSONDecoder().decode(ServerStateMessage.self, from: data)
+
+        let controller = try #require(message.payload.controller)
+        #expect(controller.repeat == .all)
+        #expect(controller.shuffle == true)
     }
 }


### PR DESCRIPTION
The spec moved repeat/shuffle off the metadata object into the server/state controller object. Surface them on the public ControllerState and drop them from TrackMetadata.

- ServerControllerState: parse repeat/shuffle (absent = keep previous)
- ServerMetadataState: remove repeat/shuffle
- ControllerState: add repeatMode/shuffle (optional; nil when unreported)
- TrackMetadata: remove repeatMode/shuffle (breaking)
- handleServerState: merge repeat/shuffle in the controller branch

Closes #29