### PR TITLE
feat(client): gate stream/request-format on an active stream

### DIFF
--- a/Sources/SendspinKit/Client/ClientTypes.swift
+++ b/Sources/SendspinKit/Client/ClientTypes.swift
@@ -194,6 +194,13 @@ public struct ControllerState: Sendable, Hashable {
     public let shuffle: Bool?
 }
 
+/// A role that carries its own independently-negotiated stream and can be the
+/// subject of a `stream/request-format`.
+public enum StreamRole: String, Sendable, Hashable {
+    case player
+    case artwork
+}
+
 /// Errors thrown by `SendspinClient` methods.
 ///
 /// Runtime errors during streaming surface as
@@ -207,6 +214,11 @@ public enum SendspinClientError: SendspinError, Equatable, LocalizedError {
     /// A command or message could not be sent over the transport.
     /// The associated string describes the underlying transport error.
     case sendFailed(String)
+    /// A `stream/request-format` was attempted for a role whose stream is not
+    /// currently active. Per spec the server answers a format request with a
+    /// `stream/start` that renegotiates an existing stream, so there is nothing
+    /// to renegotiate before the role's `stream/start` (or after its `stream/end`).
+    case streamNotActive(StreamRole)
 
     public var errorDescription: String? {
         switch self {
@@ -216,6 +228,8 @@ public enum SendspinClientError: SendspinError, Equatable, LocalizedError {
             "Already connected or connecting to a Sendspin server"
         case let .sendFailed(reason):
             "Failed to send message: \(reason)"
+        case let .streamNotActive(role):
+            "Cannot request \(role.rawValue) format: no active \(role.rawValue) stream to renegotiate"
         }
     }
 }

--- a/Sources/SendspinKit/Client/SendspinClient+Commands.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+Commands.swift
@@ -64,7 +64,12 @@ public extension SendspinClient {
     /// - Full format change: `try await requestPlayerFormat(codec: .flac, sampleRate: 48000, bitDepth: 24)`
     /// - Downgrade under load: `try await requestPlayerFormat(codec: .opus)`
     ///
-    /// - Throws: ``SendspinClientError/notConnected`` if not connected.
+    /// Only valid while a player stream is active (between its `stream/start`
+    /// and `stream/end`): the server answers with a `stream/start` that
+    /// renegotiates that stream, so there is nothing to renegotiate otherwise.
+    ///
+    /// - Throws: ``SendspinClientError/streamNotActive(_:)`` if no player stream
+    ///   is active, or ``SendspinClientError/notConnected`` if not connected.
     @MainActor
     func requestPlayerFormat(
         codec: AudioCodec? = nil,
@@ -72,6 +77,7 @@ public extension SendspinClient {
         sampleRate: Int? = nil,
         bitDepth: Int? = nil
     ) async throws {
+        guard playerStreamActive else { throw SendspinClientError.streamNotActive(.player) }
         let request = PlayerFormatRequest(
             codec: codec,
             channels: channels,
@@ -105,7 +111,11 @@ public extension SendspinClient {
     /// Request the server to change artwork format for a specific channel.
     /// The server will respond with `stream/start` containing the updated config.
     ///
-    /// - Throws: ``SendspinClientError/notConnected`` if not connected.
+    /// Only valid while an artwork stream is active (between its `stream/start`
+    /// and `stream/end`).
+    ///
+    /// - Throws: ``SendspinClientError/streamNotActive(_:)`` if no artwork stream
+    ///   is active, or ``SendspinClientError/notConnected`` if not connected.
     @MainActor
     func requestArtworkFormat(
         channel: Int,
@@ -114,6 +124,7 @@ public extension SendspinClient {
         mediaWidth: Int? = nil,
         mediaHeight: Int? = nil
     ) async throws {
+        guard artworkStreamActive else { throw SendspinClientError.streamNotActive(.artwork) }
         let request = try ArtworkFormatRequest(
             channel: channel,
             source: source,

--- a/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
@@ -222,6 +222,10 @@ extension SendspinClient {
             Log.client.info("stream/start: artwork only (no player payload)")
             return
         }
+        // Must precede the audioPlayer guard and the awaits/yields below: the gate
+        // has to be open before a consumer observes the resulting stream event, and
+        // open even when this client has no audioPlayer to actually play the stream.
+        playerStreamActive = true
         guard let audioPlayer else {
             Log.client.error("stream/start: player payload received but audioPlayer is nil!")
             return
@@ -357,6 +361,9 @@ extension SendspinClient {
         let endedRoles = message.payload.roles
 
         if endedRoles == nil || endedRoles?.contains("player") == true {
+            // Settle the gate before teardown awaits, so a reentrant format
+            // request during teardown is already rejected.
+            playerStreamActive = false
             if let audioPlayer {
                 await audioScheduler?.stop()
                 await audioScheduler?.clear()

--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -54,6 +54,14 @@ public final class SendspinClient {
     /// Current static delay in milliseconds. Initialized from `PlayerConfiguration.initialStaticDelayMs`,
     /// updated when the server sends a `set_static_delay` command.
     public private(set) var staticDelayMs: Int
+    /// Gate `stream/request-format`: a format request renegotiates an existing
+    /// stream, so it's only valid between a role's `stream/start` and `stream/end`.
+    /// Tracks the server's stream *intent*, not local playability — it opens even
+    /// when the client couldn't begin playback (e.g. an unsupported codec), which
+    /// is precisely the state a client recovers from by requesting a format it
+    /// supports. The two roles are independent — `stream/end` can end one without
+    /// the other.
+    var playerStreamActive = false
     var artworkStreamActive = false
     /// Cached from `playerConfig?.emitRawAudioEvents` to avoid optional chaining on every audio chunk.
     var shouldEmitRawAudio = false
@@ -376,12 +384,7 @@ public final class SendspinClient {
         isClockSynced = false
         currentVolume = 100 // Reset to full volume; host app can restore persisted value after reconnect
         currentMuted = false
-        updateStreamFormat(nil)
-        updateCodecHeader(nil)
-        shouldEmitRawAudio = false
-        pendingFormat = nil
-        pendingCodecHeader = nil
-        artworkStreamActive = false
+        resetStreamState()
         currentConnectionReason = nil
         currentServerId = nil
         currentMetadata = nil
@@ -390,6 +393,22 @@ public final class SendspinClient {
 
         connectionState = .disconnected
         eventsContinuation.yield(.disconnected(reason: .explicit(reason)))
+    }
+
+    /// Clear every marker of the currently-active stream(s). Shared by
+    /// ``disconnect(reason:)`` and the connection-lost path so a dropped link
+    /// leaves the same coherent "no active stream" state an explicit disconnect
+    /// would. Without this on connection loss, the `stream/request-format` gates
+    /// stay open against a dead transport, so a request would pass the gate and
+    /// then fail with the wrong error (`sendFailed`, not `streamNotActive`).
+    func resetStreamState() {
+        updateStreamFormat(nil)
+        updateCodecHeader(nil)
+        shouldEmitRawAudio = false
+        pendingFormat = nil
+        pendingCodecHeader = nil
+        playerStreamActive = false
+        artworkStreamActive = false
     }
 
     // MARK: - Outbound messages
@@ -497,6 +516,11 @@ public final class SendspinClient {
         await MainActor.run { [weak self] in
             guard let self else { return }
             if connectionState != .disconnected {
+                // Clear stream markers before announcing the loss, so a consumer
+                // reacting to `.disconnected` sees no phantom active stream. The
+                // rest of the connection (transport handle, group membership) is
+                // left for an explicit `disconnect()` or reconnect to settle.
+                resetStreamState()
                 connectionState = .disconnected
                 eventsContinuation.yield(.disconnected(reason: .connectionLost))
             }

--- a/Tests/SendspinKitTests/Integration/StreamRequestFormatTests.swift
+++ b/Tests/SendspinKitTests/Integration/StreamRequestFormatTests.swift
@@ -1,0 +1,323 @@
+// ABOUTME: Verifies stream/request-format is emitted only while the role's stream is active
+// ABOUTME: A format request renegotiates an existing stream, so it is gated on stream/start..stream/end
+
+import Foundation
+@testable import SendspinKit
+import Testing
+
+@MainActor
+struct StreamRequestFormatTests {
+    // MARK: Fixtures
+
+    private func makePlayerClient() throws -> SendspinClient {
+        try SendspinClient(
+            clientId: "test-client",
+            name: "Test Client",
+            roles: [.playerV1],
+            playerConfig: PlayerConfiguration(
+                bufferCapacity: 65_536,
+                supportedFormats: [
+                    AudioFormatSpec(codec: .pcm, channels: 1, sampleRate: 8_000, bitDepth: 16),
+                    AudioFormatSpec(codec: .flac, channels: 1, sampleRate: 8_000, bitDepth: 16)
+                ],
+                volumeMode: .none,
+                emitRawAudioEvents: true
+            )
+        )
+    }
+
+    private func makeArtworkClient() throws -> SendspinClient {
+        try SendspinClient(
+            clientId: "test-client",
+            name: "Test Client",
+            roles: [.artworkV1],
+            artworkConfig: ArtworkConfiguration(channels: [
+                ArtworkChannel(source: .album, format: .jpeg, mediaWidth: 300, mediaHeight: 300)
+            ])
+        )
+    }
+
+    private func makePlayerArtworkClient() throws -> SendspinClient {
+        try SendspinClient(
+            clientId: "test-client",
+            name: "Test Client",
+            roles: [.playerV1, .artworkV1],
+            playerConfig: PlayerConfiguration(
+                bufferCapacity: 65_536,
+                supportedFormats: [
+                    AudioFormatSpec(codec: .pcm, channels: 1, sampleRate: 8_000, bitDepth: 16)
+                ],
+                volumeMode: .none,
+                emitRawAudioEvents: true
+            ),
+            artworkConfig: ArtworkConfiguration(channels: [
+                ArtworkChannel(source: .album, format: .jpeg, mediaWidth: 300, mediaHeight: 300)
+            ])
+        )
+    }
+
+    /// `codec` is a raw wire string so callers can inject codecs the client does
+    /// not support (e.g. to exercise the unsupported-codec path).
+    private func playerStreamStartJSON(codec: String = "pcm") throws -> String {
+        let message = StreamStartMessage(payload: StreamStartPayload(
+            player: StreamStartPlayer(codec: codec, sampleRate: 8_000, channels: 1, bitDepth: 16, codecHeader: nil),
+            artwork: nil,
+            visualizer: nil
+        ))
+        return try #require(String(data: JSONEncoder().encode(message), encoding: .utf8))
+    }
+
+    private func playerArtworkStreamStartJSON() throws -> String {
+        let message = StreamStartMessage(payload: StreamStartPayload(
+            player: StreamStartPlayer(codec: "pcm", sampleRate: 8_000, channels: 1, bitDepth: 16, codecHeader: nil),
+            artwork: StreamStartArtwork(channels: [
+                StreamArtworkChannelConfig(source: .album, format: .jpeg, width: 300, height: 300)
+            ]),
+            visualizer: nil
+        ))
+        return try #require(String(data: JSONEncoder().encode(message), encoding: .utf8))
+    }
+
+    private func artworkStreamStartJSON() throws -> String {
+        let message = StreamStartMessage(payload: StreamStartPayload(
+            player: nil,
+            artwork: StreamStartArtwork(channels: [
+                StreamArtworkChannelConfig(source: .album, format: .jpeg, width: 300, height: 300)
+            ]),
+            visualizer: nil
+        ))
+        return try #require(String(data: JSONEncoder().encode(message), encoding: .utf8))
+    }
+
+    private func streamEndJSON(roles: [String]? = nil) throws -> String {
+        let message = StreamEndMessage(payload: StreamEndPayload(roles: roles))
+        return try #require(String(data: JSONEncoder().encode(message), encoding: .utf8))
+    }
+
+    /// Decode every emitted `stream/request-format`. The message's `type` is a
+    /// non-decoded constant, so frames are discriminated by the wire `type` field
+    /// instead. The transport encodes snake_case keys that match the explicit
+    /// `CodingKeys`, so a plain decoder (no key strategy) round-trips correctly.
+    private func sentRequestFormats(_ mock: MockTransport) async throws -> [StreamRequestFormatMessage] {
+        let referenceType = StreamRequestFormatMessage(payload: StreamRequestFormatPayload()).type
+        let decoder = JSONDecoder()
+        let messages = await mock.sentTextMessages
+        return try messages.compactMap { data in
+            guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  obj["type"] as? String == referenceType else { return nil }
+            return try decoder.decode(StreamRequestFormatMessage.self, from: data)
+        }
+    }
+
+    // MARK: Player gating
+
+    @Test
+    func requestPlayerFormat_throwsBeforeAnyStream() async throws {
+        let client = try makePlayerClient()
+        let mock = try await connectClient(client, activeRoles: [.playerV1])
+
+        await #expect(throws: SendspinClientError.streamNotActive(.player)) {
+            try await client.requestPlayerFormat(codec: .flac)
+        }
+        let sent = try await sentRequestFormats(mock)
+        #expect(sent.isEmpty, "No stream/request-format may be emitted without an active stream")
+
+        await client.disconnect()
+    }
+
+    @Test
+    func requestPlayerFormat_sendsWhileStreamActive() async throws {
+        let client = try makePlayerClient()
+        let mock = try await connectClient(client, activeRoles: [.playerV1])
+
+        try await mock.injectText(playerStreamStartJSON())
+        let active = await waitUntil { await MainActor.run { client.playerStreamActive } }
+        #expect(active, "Player stream should be active after stream/start")
+
+        try await client.requestPlayerFormat(codec: .flac)
+
+        let sent = try await sentRequestFormats(mock)
+        #expect(sent.count == 1)
+        #expect(sent.first?.payload.player?.codec == .flac)
+        #expect(sent.first?.payload.artwork == nil)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func requestPlayerFormat_throwsAfterStreamEnd() async throws {
+        let client = try makePlayerClient()
+        let mock = try await connectClient(client, activeRoles: [.playerV1])
+
+        try await mock.injectText(playerStreamStartJSON())
+        _ = await waitUntil { await MainActor.run { client.playerStreamActive } }
+
+        try await mock.injectText(streamEndJSON())
+        let ended = await waitUntil { await MainActor.run { !client.playerStreamActive } }
+        #expect(ended, "Player stream should be inactive after stream/end")
+
+        await #expect(throws: SendspinClientError.streamNotActive(.player)) {
+            try await client.requestPlayerFormat(codec: .flac)
+        }
+
+        await client.disconnect()
+    }
+
+    @Test
+    func requestPlayerFormat_convenienceOverloadInheritsTheGate() async throws {
+        let client = try makePlayerClient()
+        let mock = try await connectClient(client, activeRoles: [.playerV1])
+
+        let format = try AudioFormatSpec(codec: .flac, channels: 1, sampleRate: 8_000, bitDepth: 16)
+
+        // Before a stream: the AudioFormatSpec overload must be gated just like the
+        // parameterized one (it delegates to it).
+        await #expect(throws: SendspinClientError.streamNotActive(.player)) {
+            try await client.requestPlayerFormat(format)
+        }
+
+        try await mock.injectText(playerStreamStartJSON())
+        _ = await waitUntil { await MainActor.run { client.playerStreamActive } }
+
+        try await client.requestPlayerFormat(format)
+        let sent = try await sentRequestFormats(mock)
+        #expect(sent.count == 1)
+        #expect(sent.first?.payload.player?.codec == .flac)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func requestPlayerFormat_survivesMidStreamFormatChange() async throws {
+        // A second stream/start while already streaming is a format renegotiation,
+        // not a teardown — the gate must stay open across it.
+        let client = try makePlayerClient()
+        let mock = try await connectClient(client, activeRoles: [.playerV1])
+
+        try await mock.injectText(playerStreamStartJSON(codec: "pcm"))
+        _ = await waitUntil { await MainActor.run { client.currentStreamFormat?.codec == .pcm } }
+
+        try await mock.injectText(playerStreamStartJSON(codec: "flac"))
+        let changed = await waitUntil { await MainActor.run { client.currentStreamFormat?.codec == .flac } }
+        #expect(changed, "Second stream/start should update the active format")
+        #expect(client.playerStreamActive, "Gate must remain open across a mid-stream format change")
+
+        try await client.requestPlayerFormat(codec: .pcm)
+        let sent = try await sentRequestFormats(mock)
+        #expect(sent.count == 1)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func requestPlayerFormat_staysOpenWhenServerStartsUnsupportedCodec() async throws {
+        // The server started a player stream the client cannot decode. The gate
+        // still opens (the stream is active server-side) so the client can
+        // renegotiate to a codec it supports — the gate tracks server intent.
+        let client = try makePlayerClient()
+        let mock = try await connectClient(client, activeRoles: [.playerV1])
+
+        try await mock.injectText(playerStreamStartJSON(codec: "mp3"))
+        let active = await waitUntil { await MainActor.run { client.playerStreamActive } }
+        #expect(active, "Gate opens even when the codec is unsupported")
+
+        try await client.requestPlayerFormat(codec: .flac)
+        let sent = try await sentRequestFormats(mock)
+        #expect(sent.count == 1)
+        #expect(sent.first?.payload.player?.codec == .flac)
+
+        await client.disconnect()
+    }
+
+    // MARK: Connection loss
+
+    @Test
+    func requestPlayerFormat_throwsAfterConnectionLost() async throws {
+        // A dropped connection (frame stream ends without an explicit disconnect)
+        // must close the gate, so a later request fails cleanly with streamNotActive
+        // rather than passing the gate and failing with a misleading sendFailed.
+        let client = try makePlayerClient()
+        let mock = try await connectClient(client, activeRoles: [.playerV1])
+
+        try await mock.injectText(playerStreamStartJSON())
+        _ = await waitUntil { await MainActor.run { client.playerStreamActive } }
+
+        await mock.finishStreams()
+        let closed = await waitUntil { await MainActor.run { !client.playerStreamActive } }
+        #expect(closed, "Connection loss must clear the player stream gate")
+
+        await #expect(throws: SendspinClientError.streamNotActive(.player)) {
+            try await client.requestPlayerFormat(codec: .flac)
+        }
+
+        await client.disconnect()
+    }
+
+    // MARK: Artwork gating
+
+    @Test
+    func requestArtworkFormat_throwsBeforeAnyStream() async throws {
+        let client = try makeArtworkClient()
+        let mock = try await connectClient(client, activeRoles: [.artworkV1])
+
+        await #expect(throws: SendspinClientError.streamNotActive(.artwork)) {
+            try await client.requestArtworkFormat(channel: 0, format: .png)
+        }
+        let sent = try await sentRequestFormats(mock)
+        #expect(sent.isEmpty)
+
+        await client.disconnect()
+    }
+
+    @Test
+    func requestArtworkFormat_sendsWhileStreamActive() async throws {
+        let client = try makeArtworkClient()
+        let mock = try await connectClient(client, activeRoles: [.artworkV1])
+
+        try await mock.injectText(artworkStreamStartJSON())
+        let active = await waitUntil { await MainActor.run { client.artworkStreamActive } }
+        #expect(active, "Artwork stream should be active after stream/start")
+
+        try await client.requestArtworkFormat(channel: 0, format: .png)
+
+        let sent = try await sentRequestFormats(mock)
+        #expect(sent.count == 1)
+        #expect(sent.first?.payload.artwork?.channel == 0)
+        #expect(sent.first?.payload.artwork?.format == .png)
+        #expect(sent.first?.payload.player == nil)
+
+        await client.disconnect()
+    }
+
+    // MARK: Independent streams
+
+    @Test
+    func endingPlayerStreamLeavesArtworkRequestable() async throws {
+        // player and artwork are independent streams: a stream/end naming only
+        // "player" must close the player gate while leaving artwork's open.
+        let client = try makePlayerArtworkClient()
+        let mock = try await connectClient(client, activeRoles: [.playerV1, .artworkV1])
+
+        try await mock.injectText(playerArtworkStreamStartJSON())
+        let bothActive = await waitUntil {
+            await MainActor.run { client.playerStreamActive && client.artworkStreamActive }
+        }
+        #expect(bothActive, "Both streams should be active after a combined stream/start")
+
+        try await mock.injectText(streamEndJSON(roles: ["player"]))
+        let playerClosed = await waitUntil { await MainActor.run { !client.playerStreamActive } }
+        #expect(playerClosed)
+        #expect(client.artworkStreamActive, "Ending the player stream must not touch artwork")
+
+        await #expect(throws: SendspinClientError.streamNotActive(.player)) {
+            try await client.requestPlayerFormat(codec: .flac)
+        }
+        try await client.requestArtworkFormat(channel: 0, format: .png)
+
+        let sent = try await sentRequestFormats(mock)
+        #expect(sent.count == 1)
+        #expect(sent.first?.payload.artwork?.channel == 0)
+
+        await client.disconnect()
+    }
+}


### PR DESCRIPTION
A format request renegotiates an existing stream (the server answers with stream/start), so it is only meaningful for a role the server is currently streaming. Track player/artwork stream activity independently and reject a request for a role whose stream is not active.

- Add playerStreamActive alongside the existing artworkStreamActive; both settle before the triggering stream/start (or stream/end) event is observed, so a consumer reacting to that event sees the correct gate state.
- Gate requestPlayerFormat / requestArtworkFormat, throwing the new SendspinClientError.streamNotActive(StreamRole)
- The gate tracks the server's stream intent, not local playability: it opens even when the client can't decode the codec, which is precisely the state a client recovers from by requesting a format it supports.
- Clear stream state on connection loss too (shared resetStreamState helper), so a request after a dropped link fails cleanly with streamNotActive rather than passing the gate and failing with a misleading sendFailed.

Tests cover both roles across before-stream / active / after-end, the convenience overload, mid-stream format change, the unsupported-codec gate, connection loss, and player/artwork independence.

Closes #20