### PR TITLE
fix(client): fully tear down a connection lost without disconnect

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient+AudioLoops.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+AudioLoops.swift
@@ -1,0 +1,161 @@
+// ABOUTME: Audio runtime loops for SendspinClient — scheduler output and sync telemetry
+// ABOUTME: Detached tasks that drain scheduled PCM to the player and poll reanchor/telemetry
+
+import Foundation
+import os
+
+extension SendspinClient {
+    // MARK: - Scheduler output
+
+    /// Number of chunks to pre-buffer before rebuilding the AudioQueue during
+    /// a format transition. This gives the AudioQueue headroom so the sync
+    /// correction doesn't engage aggressively on the first few samples.
+    /// 2 chunks ≈ 200ms — enough headroom without overshooting.
+    nonisolated static let formatTransitionPreBuffer = 2
+
+    nonisolated func runSchedulerOutput() async {
+        guard let audioScheduler = await audioScheduler,
+              let audioPlayer = await audioPlayer
+        else { return }
+
+        var activeGeneration: UInt64 = await streamGeneration
+
+        for await chunk in audioScheduler.scheduledChunks {
+            if chunk.generation != activeGeneration {
+                if chunk.generation < activeGeneration {
+                    // Old-generation chunk after a format change already happened.
+                    // This shouldn't occur since old chunks have earlier timestamps,
+                    // but discard just in case.
+                    continue
+                }
+
+                // New generation — first chunk decoded in the new format.
+                // Accumulate a few chunks before rebuilding the AudioQueue
+                // so we have buffer headroom for clean sync convergence.
+                let pending = await MainActor.run { () -> (AudioFormatSpec?, Data?) in
+                    let fmt = self.pendingFormat
+                    let hdr = self.pendingCodecHeader
+                    self.pendingFormat = nil
+                    self.pendingCodecHeader = nil
+                    return (fmt, hdr)
+                }
+
+                activeGeneration = chunk.generation
+
+                guard let format = pending.0 else {
+                    try? await audioPlayer.playPCM(chunk.pcmData, serverTimestamp: chunk.originalTimestamp)
+                    continue
+                }
+
+                // Pre-buffer: collect this chunk + one more before switching
+                var preBuffer: [(pcm: Data, timestamp: Int64)] = [
+                    (chunk.pcmData, chunk.originalTimestamp)
+                ]
+
+                for await nextChunk in audioScheduler.scheduledChunks {
+                    preBuffer.append((nextChunk.pcmData, nextChunk.originalTimestamp))
+                    if preBuffer.count >= Self.formatTransitionPreBuffer {
+                        break
+                    }
+                }
+
+                // Rebuild AudioQueue and feed pre-buffered chunks
+                Log.client.info("Seamless switch: rebuilding AudioQueue at \(format.sampleRate)Hz (pre-buffered \(preBuffer.count) chunks)")
+                try? await audioPlayer.start(format: format, codecHeader: pending.1)
+
+                for buffered in preBuffer {
+                    try? await audioPlayer.playPCM(buffered.pcm, serverTimestamp: buffered.timestamp)
+                }
+                continue
+            }
+            try? await audioPlayer.playPCM(chunk.pcmData, serverTimestamp: chunk.originalTimestamp)
+        }
+    }
+
+    /// Polls for reanchor requests from the audio callback and logs telemetry.
+    /// Sync correction is now computed inside the AudioQueue callback itself,
+    /// so this loop only handles rare reanchor events and periodic logging.
+    nonisolated func runSyncCorrectionAndTelemetry() async {
+        var lastTelemetryStats = SchedulerStats()
+        var tickCount = 0
+        var underrunMonitor = UnderrunMonitor()
+
+        while !Task.isCancelled {
+            // 500ms poll — reanchors are rare events, no need to check faster.
+            // Telemetry logs every 4th tick (2s).
+            try? await Task.sleep(for: .milliseconds(500))
+            tickCount += 1
+
+            guard let audioScheduler = await audioScheduler,
+                  let clockSync = await clockSync,
+                  let audioPlayer = await audioPlayer else { continue }
+
+            // --- Poll for reanchor requests from the audio callback ---
+            if let reanchorTarget = await audioPlayer.pollReanchor() {
+                await audioPlayer.reanchorCursor(to: reanchorTarget)
+            }
+
+            let tSnap = await audioPlayer.telemetrySnapshot
+
+            // Report buffer starvation as `error`/`synchronized` (spec §Playback
+            // Synchronization). The audio callback only counts underruns; this
+            // off-thread loop is where we can reach the server.
+            switch await clientOperationalState {
+            case .externalSource:
+                // Re-baseline: underruns accrued while not playing must not trip an
+                // error once we rejoin.
+                underrunMonitor.resetBaseline(underrunCount: tSnap.underrunCount)
+            case .synchronized, .error:
+                await applyUnderrunTransition(underrunMonitor.observe(underrunCount: tSnap.underrunCount))
+            }
+
+            // --- Telemetry (every 2s = every 4 ticks) ---
+            if tickCount % 4 == 0 {
+                let currentStats = await audioScheduler.stats
+                guard currentStats.received > 0 else { continue }
+
+                // Atomic snapshot of clock-sync state — single actor hop covers
+                // offset, RTT, and the Kalman convergence diagnostics.
+                guard let syncSnap = await clockSync.diagnosticSnapshot() else { continue }
+
+                let framesScheduled = currentStats.received - lastTelemetryStats.received
+                let framesPlayed = currentStats.played - lastTelemetryStats.played
+                let framesDroppedLate = currentStats.droppedLate - lastTelemetryStats.droppedLate
+
+                let clockOffsetMs = Double(syncSnap.offset) / 1_000.0
+                let rttMs = Double(syncSnap.rtt) / 1_000.0
+                let estErrUs = Int64(syncSnap.estimatedError.rounded())
+                // Drift is dimensionless (μs of offset per μs of time); ppm is the
+                // human-readable form for clock-drift rates.
+                let driftPpm = syncSnap.drift * 1_000_000.0
+
+                // Sync error computed by the audio callback (precise, no actor jitter);
+                // reuse the per-tick telemetry snapshot read above.
+                let syncErrorUs = tSnap.syncErrorUs
+                let dropN = tSnap.correctionSchedule.dropEveryNFrames
+                let insertN = tSnap.correctionSchedule.insertEveryNFrames
+
+                let correcting = tSnap.correctionSchedule.isCorrecting
+
+                // Telemetry is pre-formatted into a single String because os.Logger's
+                // type checker can't handle this many inline interpolation segments.
+                // The cost (unconditional formatting) is acceptable at the 2s tick rate.
+                let telemetry = "sched=\(framesScheduled) played=\(framesPlayed)"
+                    + " late=\(framesDroppedLate)"
+                    + " buf=\(String(format: "%.1f", currentStats.bufferFillMs))ms"
+                    + " offset=\(String(format: "%.2f", clockOffsetMs))ms"
+                    + " rtt=\(String(format: "%.2f", rttMs))ms"
+                    + " est=\(estErrUs)us"
+                    + " drift=\(String(format: "%.2f", driftPpm))ppm"
+                    + " samples=\(syncSnap.sampleCount)"
+                    + " queue=\(currentStats.queueSize)"
+                    + " sync=\(syncErrorUs)us"
+                    + " correcting=\(correcting)"
+                    + " drop=\(dropN) insert=\(insertN)"
+                Log.client.debug("\(telemetry, privacy: .public)")
+
+                lastTelemetryStats = currentStats
+            }
+        }
+    }
+}

--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -98,6 +98,21 @@ public final class SendspinClient {
     var clockSyncTask: Task<Void, Never>?
     var schedulerOutputTask: Task<Void, Never>?
     var syncTelemetryTask: Task<Void, Never>?
+    /// Bumped on every ``setupConnection(with:preReadHello:)``. A message loop
+    /// captures the value live at its creation; on exit it tears the connection
+    /// down only if the value still matches, so a loop superseded by a fast
+    /// reconnect (e.g. a network-path change firing before its `.disconnected`
+    /// event drains) cannot clobber the connection that replaced it.
+    var connectionGeneration: UInt64 = 0
+
+    /// The reason an in-flight ``disconnect(reason:)`` intends to report, recorded
+    /// before it suspends on the goodbye send. If a connection loss races that
+    /// suspended disconnect and settles first, it adopts this reason instead of
+    /// `.connectionLost`, so the local `.disconnected` event preserves the user's
+    /// intent — host apps branch on it (e.g. suppress auto-reconnect on
+    /// `.userRequest`/`.anotherServer`, but retry on `.connectionLost`). Consumed
+    /// by the settling teardown and cleared on each new connection.
+    var explicitDisconnectReason: GoodbyeReason?
 
     // Event stream
     let eventsContinuation: AsyncStream<ClientEvent>.Continuation
@@ -279,6 +294,17 @@ public final class SendspinClient {
         // re-hello, where the accumulated state is still valid.
         resetServerSessionState()
 
+        // Establish this connection's identity before any `await` below. A stale
+        // handleConnectionLost(generation:) from a prior link that interleaves during
+        // those suspensions then sees the bumped generation and skips its teardown,
+        // instead of clobbering the connection now being set up.
+        connectionGeneration &+= 1
+        let generation = connectionGeneration
+
+        // A fresh session never inherits a prior disconnect's reason: drop any intent
+        // a disconnect recorded but didn't settle (it bailed on a generation change).
+        explicitDisconnectReason = nil
+
         let clockSync = ClockSynchronizer()
         let audioScheduler = AudioScheduler(clockSync: clockSync)
 
@@ -320,7 +346,7 @@ public final class SendspinClient {
         let frames = transport.frames
 
         messageLoopTask = Task.detached { [weak self] in
-            await self?.runMessageLoop(frames: frames)
+            await self?.runMessageLoop(frames: frames, generation: generation)
         }
 
         // Clock sync starts after server/hello is received (in handleServerHello)
@@ -357,6 +383,13 @@ public final class SendspinClient {
         // ghost `.disconnected` event (not harmless — it spams event consumers).
         guard connectionState != .disconnected else { return }
 
+        let generation = connectionGeneration
+
+        // Record intent before the goodbye await: if a connection loss races this
+        // suspended disconnect and settles first, it reports this reason, not
+        // `.connectionLost`.
+        explicitDisconnectReason = reason
+
         // Send client/goodbye before tearing down (best-effort)
         if let transport {
             let goodbye = ClientGoodbyeMessage(
@@ -365,40 +398,32 @@ public final class SendspinClient {
             try? await transport.send(goodbye)
         }
 
-        messageLoopTask?.cancel()
-        clockSyncTask?.cancel()
-        schedulerOutputTask?.cancel()
-        syncTelemetryTask?.cancel()
-        messageLoopTask = nil
-        clockSyncTask = nil
-        schedulerOutputTask = nil
-        syncTelemetryTask = nil
+        // Shared guarded teardown: bails (emitting nothing) if a connection-loss
+        // teardown or a competing connection already settled this one while the
+        // goodbye was in flight — collapsing the race to a single `.disconnected`.
+        guard await teardownLiveConnection(generation: generation) else { return }
 
-        if let audioPlayer {
-            await audioPlayer.stop()
-        }
-
-        await audioScheduler?.finish()
-        await audioScheduler?.clear()
-        await transport?.disconnect()
-
-        transport = nil
-        clockSync = nil
-        audioScheduler = nil
-        audioPlayer = nil
-
-        clientOperationalState = .synchronized
-        isClockSynced = false
         currentVolume = 100 // Reset to full volume; host app can restore persisted value after reconnect
         currentMuted = false
-        resetStreamState()
         resetServerSessionState()
         currentConnectionReason = nil
         currentServerId = nil
         // Don't clear currentGroup — spec says group membership persists across reconnections
 
+        settleDisconnected()
+    }
+
+    /// Settle `connectionState` to `.disconnected` and emit a single `.disconnected`
+    /// event. Shared by ``disconnect(reason:)`` and ``handleConnectionLost(generation:)``
+    /// so the emitted reason is resolved in one place: an explicit disconnect's intent
+    /// wins if one is in flight, otherwise it's a `.connectionLost`. Must be called with
+    /// no `await` between the teardown's final guard and here, so racing teardowns
+    /// cannot double-settle.
+    private func settleDisconnected() {
         connectionState = .disconnected
-        eventsContinuation.yield(.disconnected(reason: .explicit(reason)))
+        let reason: DisconnectReason = explicitDisconnectReason.map(DisconnectReason.explicit) ?? .connectionLost
+        explicitDisconnectReason = nil
+        eventsContinuation.yield(.disconnected(reason: reason))
     }
 
     /// Clear every marker of the currently-active stream(s). Shared by
@@ -427,6 +452,23 @@ public final class SendspinClient {
     func resetServerSessionState() {
         updateMetadata(nil)
         updateControllerState(nil)
+    }
+
+    /// Cancel and release the four long-lived connection tasks. Shared by
+    /// ``disconnect(reason:)`` and the connection-lost path. The latter cannot
+    /// rely on a later `disconnect()` to do this: once connection loss sets
+    /// `.disconnected`, `disconnect()` hits its idempotency guard and returns
+    /// before reaching here, which is how the scheduler-output and telemetry
+    /// loops would otherwise leak (and double-run after a reconnect).
+    func cancelConnectionTasks() {
+        messageLoopTask?.cancel()
+        clockSyncTask?.cancel()
+        schedulerOutputTask?.cancel()
+        syncTelemetryTask?.cancel()
+        messageLoopTask = nil
+        clockSyncTask = nil
+        schedulerOutputTask = nil
+        syncTelemetryTask = nil
     }
 
     // MARK: - Outbound messages
@@ -519,7 +561,7 @@ public final class SendspinClient {
     /// be handled only after the audio chunks the server sent before it). Audio
     /// *output* is decoupled on ``runSchedulerOutput()``, so serial frame
     /// dispatch here does not gate playback.
-    private nonisolated func runMessageLoop(frames: AsyncStream<TransportFrame>) async {
+    private nonisolated func runMessageLoop(frames: AsyncStream<TransportFrame>, generation: UInt64) async {
         for await frame in frames {
             switch frame {
             case let .text(text):
@@ -530,173 +572,82 @@ public final class SendspinClient {
         }
 
         // The frame stream ended — connection was lost (not an explicit disconnect,
-        // which cancels this task before streams end naturally)
-        await MainActor.run { [weak self] in
-            guard let self else { return }
-            if connectionState != .disconnected {
-                // Clear stream markers before announcing the loss, so a consumer
-                // reacting to `.disconnected` sees no phantom active stream. The
-                // rest of the connection (transport handle, group membership) is
-                // left for an explicit `disconnect()` or reconnect to settle.
-                resetStreamState()
-                connectionState = .disconnected
-                eventsContinuation.yield(.disconnected(reason: .connectionLost))
-            }
-        }
+        // which cancels this task before streams end naturally).
+        await handleConnectionLost(generation: generation)
     }
 
-    // MARK: - Scheduler output
-
-    /// Number of chunks to pre-buffer before rebuilding the AudioQueue during
-    /// a format transition. This gives the AudioQueue headroom so the sync
-    /// correction doesn't engage aggressively on the first few samples.
-    /// 2 chunks ≈ 200ms — enough headroom without overshooting.
-    private nonisolated static let formatTransitionPreBuffer = 2
-
-    private nonisolated func runSchedulerOutput() async {
-        guard let audioScheduler = await audioScheduler,
-              let audioPlayer = await audioPlayer
-        else { return }
-
-        var activeGeneration: UInt64 = await streamGeneration
-
-        for await chunk in audioScheduler.scheduledChunks {
-            if chunk.generation != activeGeneration {
-                if chunk.generation < activeGeneration {
-                    // Old-generation chunk after a format change already happened.
-                    // This shouldn't occur since old chunks have earlier timestamps,
-                    // but discard just in case.
-                    continue
-                }
-
-                // New generation — first chunk decoded in the new format.
-                // Accumulate a few chunks before rebuilding the AudioQueue
-                // so we have buffer headroom for clean sync convergence.
-                let pending = await MainActor.run { () -> (AudioFormatSpec?, Data?) in
-                    let fmt = self.pendingFormat
-                    let hdr = self.pendingCodecHeader
-                    self.pendingFormat = nil
-                    self.pendingCodecHeader = nil
-                    return (fmt, hdr)
-                }
-
-                activeGeneration = chunk.generation
-
-                guard let format = pending.0 else {
-                    try? await audioPlayer.playPCM(chunk.pcmData, serverTimestamp: chunk.originalTimestamp)
-                    continue
-                }
-
-                // Pre-buffer: collect this chunk + one more before switching
-                var preBuffer: [(pcm: Data, timestamp: Int64)] = [
-                    (chunk.pcmData, chunk.originalTimestamp)
-                ]
-
-                for await nextChunk in audioScheduler.scheduledChunks {
-                    preBuffer.append((nextChunk.pcmData, nextChunk.originalTimestamp))
-                    if preBuffer.count >= Self.formatTransitionPreBuffer {
-                        break
-                    }
-                }
-
-                // Rebuild AudioQueue and feed pre-buffered chunks
-                Log.client.info("Seamless switch: rebuilding AudioQueue at \(format.sampleRate)Hz (pre-buffered \(preBuffer.count) chunks)")
-                try? await audioPlayer.start(format: format, codecHeader: pending.1)
-
-                for buffered in preBuffer {
-                    try? await audioPlayer.playPCM(buffered.pcm, serverTimestamp: buffered.timestamp)
-                }
-                continue
-            }
-            try? await audioPlayer.playPCM(chunk.pcmData, serverTimestamp: chunk.originalTimestamp)
-        }
+    /// Tear down a connection that dropped without an explicit ``disconnect(reason:)``.
+    ///
+    /// Mirrors `disconnect()`'s resource teardown — stop audio, finish the
+    /// scheduler, close and release the transport, cancel the connection tasks —
+    /// so a dropped link leaves no live AudioQueue, socket, or background loop.
+    /// It deliberately preserves the *observable* session state (metadata,
+    /// controller, group, volume, server identity) so a UI keeps showing the
+    /// last-known state through a transient drop; that state is reset at the next
+    /// connection by ``setupConnection(with:preReadHello:)``, not here.
+    ///
+    /// - Parameter generation: the connection generation this loop was started
+    ///   for. If a newer connection has since been established, this teardown is
+    ///   stale and must do nothing.
+    ///
+    /// Internal rather than private so the generation guard can be tested directly
+    /// (its failure mode — a stale teardown clobbering a live reconnect — is a race
+    /// that can't be reproduced deterministically through the public surface).
+    @MainActor
+    func handleConnectionLost(generation: UInt64) async {
+        guard await teardownLiveConnection(generation: generation) else { return }
+        settleDisconnected()
     }
 
-    /// Polls for reanchor requests from the audio callback and logs telemetry.
-    /// Sync correction is now computed inside the AudioQueue callback itself,
-    /// so this loop only handles rare reanchor events and periodic logging.
-    private nonisolated func runSyncCorrectionAndTelemetry() async {
-        var lastTelemetryStats = SchedulerStats()
-        var tickCount = 0
-        var underrunMonitor = UnderrunMonitor()
+    /// Idempotently tear down the live connection's resources — stop audio, finish
+    /// the scheduler, close and release the transport, cancel the background tasks —
+    /// guarding against a competing connection that replaced them while suspended.
+    ///
+    /// Returns `true` if this call performed the teardown; `false` if a newer
+    /// connection has taken over (generation bumped) or another teardown path
+    /// already settled this one. On `false` the caller must not settle
+    /// `connectionState` or emit an event.
+    ///
+    /// Shared by ``handleConnectionLost(generation:)`` and ``disconnect(reason:)`` so
+    /// concurrent teardowns (a user disconnect racing a dropped link) collapse to a
+    /// single settle and a single `.disconnected` event. The observable session
+    /// state (metadata, controller, group, volume, server identity) is intentionally
+    /// left for the caller to handle — connection-loss preserves it; explicit
+    /// disconnect resets it.
+    @MainActor
+    func teardownLiveConnection(generation: UInt64) async -> Bool {
+        guard generation == connectionGeneration, connectionState != .disconnected else { return false }
 
-        while !Task.isCancelled {
-            // 500ms poll — reanchors are rare events, no need to check faster.
-            // Telemetry logs every 4th tick (2s).
-            try? await Task.sleep(for: .milliseconds(500))
-            tickCount += 1
+        // Operate on captured locals, not `self.*`: these awaits suspend the
+        // MainActor, during which a competing connection can replace the live
+        // dependencies. Closing the locals tears down the resources this connection
+        // owned, never a replacement's. Teardown is idempotent, so re-running it on
+        // already-closed resources (a concurrent disconnect got here first) is safe.
+        let closingPlayer = audioPlayer
+        let closingScheduler = audioScheduler
+        let closingTransport = transport
 
-            guard let audioScheduler = await audioScheduler,
-                  let clockSync = await clockSync,
-                  let audioPlayer = await audioPlayer else { continue }
+        await closingPlayer?.stop()
+        await closingScheduler?.finish()
+        await closingScheduler?.clear()
+        await closingTransport?.disconnect()
 
-            // --- Poll for reanchor requests from the audio callback ---
-            if let reanchorTarget = await audioPlayer.pollReanchor() {
-                await audioPlayer.reanchorCursor(to: reanchorTarget)
-            }
+        // Re-check before mutating shared state. There must be no `await` between
+        // here and the caller's `connectionState = .disconnected`, so two racing
+        // teardowns cannot both pass this guard and double-settle.
+        guard generation == connectionGeneration, connectionState != .disconnected else { return false }
 
-            let tSnap = await audioPlayer.telemetrySnapshot
+        transport = nil
+        clockSync = nil
+        audioScheduler = nil
+        audioPlayer = nil
 
-            // Report buffer starvation as `error`/`synchronized` (spec §Playback
-            // Synchronization). The audio callback only counts underruns; this
-            // off-thread loop is where we can reach the server.
-            switch await clientOperationalState {
-            case .externalSource:
-                // Re-baseline: underruns accrued while not playing must not trip an
-                // error once we rejoin.
-                underrunMonitor.resetBaseline(underrunCount: tSnap.underrunCount)
-            case .synchronized, .error:
-                await applyUnderrunTransition(underrunMonitor.observe(underrunCount: tSnap.underrunCount))
-            }
+        cancelConnectionTasks()
 
-            // --- Telemetry (every 2s = every 4 ticks) ---
-            if tickCount % 4 == 0 {
-                let currentStats = await audioScheduler.stats
-                guard currentStats.received > 0 else { continue }
-
-                // Atomic snapshot of clock-sync state — single actor hop covers
-                // offset, RTT, and the Kalman convergence diagnostics.
-                guard let syncSnap = await clockSync.diagnosticSnapshot() else { continue }
-
-                let framesScheduled = currentStats.received - lastTelemetryStats.received
-                let framesPlayed = currentStats.played - lastTelemetryStats.played
-                let framesDroppedLate = currentStats.droppedLate - lastTelemetryStats.droppedLate
-
-                let clockOffsetMs = Double(syncSnap.offset) / 1_000.0
-                let rttMs = Double(syncSnap.rtt) / 1_000.0
-                let estErrUs = Int64(syncSnap.estimatedError.rounded())
-                // Drift is dimensionless (μs of offset per μs of time); ppm is the
-                // human-readable form for clock-drift rates.
-                let driftPpm = syncSnap.drift * 1_000_000.0
-
-                // Sync error computed by the audio callback (precise, no actor jitter);
-                // reuse the per-tick telemetry snapshot read above.
-                let syncErrorUs = tSnap.syncErrorUs
-                let dropN = tSnap.correctionSchedule.dropEveryNFrames
-                let insertN = tSnap.correctionSchedule.insertEveryNFrames
-
-                let correcting = tSnap.correctionSchedule.isCorrecting
-
-                // Telemetry is pre-formatted into a single String because os.Logger's
-                // type checker can't handle this many inline interpolation segments.
-                // The cost (unconditional formatting) is acceptable at the 2s tick rate.
-                let telemetry = "sched=\(framesScheduled) played=\(framesPlayed)"
-                    + " late=\(framesDroppedLate)"
-                    + " buf=\(String(format: "%.1f", currentStats.bufferFillMs))ms"
-                    + " offset=\(String(format: "%.2f", clockOffsetMs))ms"
-                    + " rtt=\(String(format: "%.2f", rttMs))ms"
-                    + " est=\(estErrUs)us"
-                    + " drift=\(String(format: "%.2f", driftPpm))ppm"
-                    + " samples=\(syncSnap.sampleCount)"
-                    + " queue=\(currentStats.queueSize)"
-                    + " sync=\(syncErrorUs)us"
-                    + " correcting=\(correcting)"
-                    + " drop=\(dropN) insert=\(insertN)"
-                Log.client.debug("\(telemetry, privacy: .public)")
-
-                lastTelemetryStats = currentStats
-            }
-        }
+        clientOperationalState = .synchronized
+        isClockSynced = false
+        resetStreamState()
+        return true
     }
 
     // MARK: - Utilities

--- a/Tests/SendspinKitTests/Helpers/MockTransport.swift
+++ b/Tests/SendspinKitTests/Helpers/MockTransport.swift
@@ -26,6 +26,10 @@ actor MockTransport: SendspinTransport {
     private(set) var isConnected = true
     private(set) var disconnectCalled = false
 
+    /// When enabled, a `client/goodbye` send suspends until ``releaseGoodbyeGate()``.
+    private var goodbyeGateEnabled = false
+    private var goodbyeGateContinuation: CheckedContinuation<Void, Never>?
+
     private let encoder = SendspinEncoding.makeEncoder()
 
     init() {
@@ -39,6 +43,14 @@ actor MockTransport: SendspinTransport {
             throw MockTransportError.simulatedFailure
         }
         let data = try encoder.encode(message)
+        // Deterministic seam for the disconnect-vs-loss race: block only the
+        // `client/goodbye` send so a test can pin `disconnect()` past its entry
+        // guard, mid-teardown, while another teardown path runs.
+        // Match "goodbye" rather than the full "client/goodbye": JSONEncoder escapes
+        // the slash ("client\/goodbye"), and only the goodbye message carries the word.
+        if goodbyeGateEnabled, let text = String(data: data, encoding: .utf8), text.contains("goodbye") {
+            await withCheckedContinuation { goodbyeGateContinuation = $0 }
+        }
         sentTextMessages.append(data)
     }
 
@@ -81,6 +93,24 @@ actor MockTransport: SendspinTransport {
     /// so this method provides the cross-isolation mutation point.
     func setShouldFailOnSend(_ value: Bool) {
         shouldFailOnSend = value
+    }
+
+    /// Arm the goodbye gate: the next `client/goodbye` send will suspend until
+    /// ``releaseGoodbyeGate()``.
+    func enableGoodbyeGate() {
+        goodbyeGateEnabled = true
+    }
+
+    /// Whether a `client/goodbye` send is currently parked on the gate.
+    var isGoodbyeGateWaiting: Bool {
+        goodbyeGateContinuation != nil
+    }
+
+    /// Release a parked goodbye send and disarm the gate.
+    func releaseGoodbyeGate() {
+        goodbyeGateEnabled = false
+        goodbyeGateContinuation?.resume()
+        goodbyeGateContinuation = nil
     }
 }
 

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -405,6 +405,10 @@ struct ClientIntegrationTests {
 
         #expect(client.currentServerId == newServerId)
         #expect(client.connectionState == .connected)
+        // The superseded old connection's teardown must not have clobbered the new
+        // transport: a stale handleConnectionLost interleaving the switch is gated
+        // out by the connection generation.
+        #expect(client.transport != nil, "Competing-switch must leave the new transport live")
         // Left the old server with `another_server`, and dropped it.
         let oldGoodbyes = await sentGoodbyeReasons(from: mock1)
         let oldDisconnected = await mock1.disconnectCalled

--- a/Tests/SendspinKitTests/Integration/ConnectionLostTeardownTests.swift
+++ b/Tests/SendspinKitTests/Integration/ConnectionLostTeardownTests.swift
@@ -1,0 +1,162 @@
+// ABOUTME: Verifies a connection lost without an explicit disconnect tears down live resources
+// ABOUTME: while preserving observable session state, and that a superseded teardown is ignored
+
+import Foundation
+@testable import SendspinKit
+import Testing
+
+@MainActor
+struct ConnectionLostTeardownTests {
+    // MARK: Fixtures
+
+    private func metadataJSON(title: String) throws -> String {
+        let message = ServerStateMessage(payload: ServerStatePayload(
+            metadata: ServerMetadataState(title: .value(title))
+        ))
+        return try #require(String(data: JSONEncoder().encode(message), encoding: .utf8))
+    }
+
+    private func groupUpdateJSON(groupId: String, groupName: String) throws -> String {
+        let message = GroupUpdateMessage(payload: GroupUpdatePayload(
+            playbackState: nil,
+            groupId: groupId,
+            groupName: groupName
+        ))
+        return try #require(String(data: JSONEncoder().encode(message), encoding: .utf8))
+    }
+
+    // MARK: Resource teardown
+
+    @Test
+    func connectionLossReleasesLiveResources() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        await mock.finishStreams()
+        try await waitForState(client, expected: .disconnected, timeout: .seconds(3))
+
+        #expect(client.transport == nil, "Transport must be released on connection loss")
+        #expect(client.messageLoopTask == nil)
+        #expect(client.clockSyncTask == nil)
+        #expect(client.schedulerOutputTask == nil)
+        #expect(client.syncTelemetryTask == nil)
+
+        // A command now reports the honest .notConnected instead of silently
+        // mutating a dead connection.
+        await #expect(throws: SendspinClientError.notConnected) {
+            try await client.setVolume(50)
+        }
+    }
+
+    @Test
+    func connectionLossPreservesObservableState() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        try await mock.injectText(metadataJSON(title: "Now Playing"))
+        try await mock.injectText(groupUpdateJSON(groupId: "g1", groupName: "Kitchen"))
+        _ = await waitUntil {
+            await MainActor.run {
+                client.currentMetadata?.title == "Now Playing" && client.currentGroup?.groupId == "g1"
+            }
+        }
+
+        await mock.finishStreams()
+        try await waitForState(client, expected: .disconnected, timeout: .seconds(3))
+
+        // A transient drop must not blank the UI: last-known state stays observable
+        // until the next connection replaces it.
+        #expect(client.currentMetadata?.title == "Now Playing", "Metadata must survive a transient drop")
+        #expect(client.currentGroup?.groupId == "g1", "Group must survive a transient drop")
+    }
+
+    // MARK: Generation guard
+
+    @Test
+    func staleConnectionLostIsIgnored() async throws {
+        let client = try makeTestClient()
+        _ = try await connectClient(client)
+
+        // A teardown tagged for an older generation — a message loop superseded by
+        // a fast reconnect holds the generation it started with, which is lower
+        // than the current one — must not touch the connection that replaced it.
+        await client.handleConnectionLost(generation: client.connectionGeneration &- 1)
+
+        #expect(client.connectionState == .connected, "Stale teardown must not disconnect the live connection")
+        #expect(client.transport != nil, "Stale teardown must not release the live transport")
+        #expect(client.messageLoopTask != nil, "Stale teardown must not cancel the live tasks")
+
+        await client.disconnect()
+    }
+
+    @Test
+    func concurrentDisconnectAndLossEmitsSingleDisconnectedEvent() async throws {
+        let client = try makeTestClient()
+        let mock = try await connectClient(client)
+
+        let collector = EventBox()
+        let collectTask = Task { for await event in client.events {
+            await collector.append(event)
+        } }
+
+        // Block the goodbye send so disconnect() is pinned past its entry guard but
+        // before it settles state.
+        await mock.enableGoodbyeGate()
+        async let disconnecting: Void = client.disconnect(reason: .userRequest)
+        let parked = await waitUntil { await mock.isGoodbyeGateWaiting }
+        #expect(parked, "disconnect() should be parked on the goodbye send")
+
+        // While disconnect is suspended, a connection-loss teardown completes and
+        // settles the connection (yielding .connectionLost).
+        await client.handleConnectionLost(generation: client.connectionGeneration)
+
+        // Let disconnect resume and run to completion.
+        await mock.releaseGoodbyeGate()
+        await disconnecting
+
+        // Exactly one .disconnected event must reach consumers — never a duplicate
+        // because both teardown paths each emitted one. Negative wait: confirm a
+        // second never arrives.
+        let reachedTwo = await waitUntil(timeout: .milliseconds(300)) { await collector.disconnectedCount >= 2 }
+        collectTask.cancel()
+        #expect(!reachedTwo, "A disconnect racing a connection loss must not emit two .disconnected events")
+        #expect(await collector.disconnectedCount == 1)
+        #expect(client.connectionState == .disconnected)
+
+        // The loss settled first, but the user's explicit intent must still win the
+        // reported reason — a host app branches on it (no auto-reconnect on a user
+        // request) and must not see a spurious .connectionLost.
+        #expect(await collector.disconnectedReasons == [.explicit(.userRequest)], "explicit reason must survive a racing loss")
+    }
+
+    @Test
+    func matchingConnectionLostTearsDown() async throws {
+        let client = try makeTestClient()
+        _ = try await connectClient(client)
+
+        // The same call with the current generation does tear down — proving the
+        // guard above rejects on generation, not because the method is inert.
+        await client.handleConnectionLost(generation: client.connectionGeneration)
+
+        #expect(client.connectionState == .disconnected)
+        #expect(client.transport == nil)
+        #expect(client.messageLoopTask == nil)
+    }
+}
+
+/// Accumulates client events for assertions about how many of a kind were emitted.
+private actor EventBox {
+    private var events: [ClientEvent] = []
+
+    func append(_ event: ClientEvent) {
+        events.append(event)
+    }
+
+    var disconnectedCount: Int {
+        events.count(where: { if case .disconnected = $0 { true } else { false } })
+    }
+
+    var disconnectedReasons: [DisconnectReason] {
+        events.compactMap { if case let .disconnected(reason) = $0 { reason } else { nil } }
+    }
+}


### PR DESCRIPTION
A dropped link previously only reset the stream markers, leaking the clock-sync, scheduler-output (blocked forever on an AudioScheduler only disconnect() finishes), and telemetry tasks — the latter double-pumping the next connection after reconnect. handleConnectionLost() now shares disconnect()'s resource teardown via a guarded teardownLiveConnection(generation:), while preserving observable session state so a UI survives a transient drop. A per-connection generation, captured locals re-checked after the teardown awaits, and a settle with no await before it together keep a reconnect, a competing connection, and a disconnect()-vs-loss race from clobbering each other or double-firing .disconnected. The surviving event also keeps the right reason: disconnect() records its intent before the goodbye send, so a racing loss reports .anotherServer/.userRequest (which host apps branch on) instead of .connectionLost.

Extracts the two audio runtime loops into SendspinClient+AudioLoops.swift to stay under the 900-line file_length cap CI enforces with --strict.