### PR TITLE
test(client): dispatch sent-message assertions on the wire type tag

### DIFF
--- a/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MessageHandling.swift
@@ -14,9 +14,7 @@ extension SendspinClient {
         // This avoids the O(n) try-all-types chain where every message pays the cost
         // of trying earlier types, and eliminates cross-type ambiguity from messages
         // with all-optional payloads (like ServerStateMessage).
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let msgType = json["type"] as? String
-        else {
+        guard let msgType = SendspinEncoding.messageType(of: data) else {
             Log.client.error("Message missing 'type' field: \(text.prefix(200))")
             return
         }

--- a/Sources/SendspinKit/Client/SendspinClient+MultiServer.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+MultiServer.swift
@@ -121,8 +121,7 @@ extension SendspinClient {
     /// message type. Mirrors the type-first dispatch in `handleTextMessage`.
     private nonisolated static func decodeServerHello(_ text: String) -> ServerHelloMessage? {
         guard let data = text.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              json["type"] as? String == "server/hello"
+              SendspinEncoding.messageType(of: data) == "server/hello"
         else { return nil }
         return try? JSONDecoder().decode(ServerHelloMessage.self, from: data)
     }

--- a/Sources/SendspinKit/Transport/SendspinEncoding.swift
+++ b/Sources/SendspinKit/Transport/SendspinEncoding.swift
@@ -1,5 +1,5 @@
 // ABOUTME: JSON encoding utilities for the Sendspin wire format
-// ABOUTME: Provides a configured encoder factory for transport implementations
+// ABOUTME: Provides a configured encoder factory and the wire-type dispatch tag reader
 
 import Foundation
 
@@ -15,5 +15,16 @@ enum SendspinEncoding {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         return encoder
+    }
+
+    /// The `type` tag of a wire frame, read without decoding the payload.
+    ///
+    /// Every Sendspin frame is `{ "type": "...", "payload": {...} }`. Callers MUST
+    /// read this tag and dispatch on it *before* decoding the concrete message: each
+    /// message's `type` is a `let` constant the synthesized decoder leaves untouched,
+    /// and payloads are all-optional, so any frame decodes "successfully" as the wrong
+    /// type. The wire tag is the only reliable discriminator.
+    static func messageType(of data: Data) -> String? {
+        (try? JSONSerialization.jsonObject(with: data) as? [String: Any])?["type"] as? String
     }
 }

--- a/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientIntegrationTests.swift
@@ -222,17 +222,22 @@ private func collectEvent(
     }
 }
 
-/// Decode the last `ClientCommandMessage` from the mock's sent messages.
+/// Decode the last `client/command` sent after `offset`.
 ///
 /// The mock encodes with `.convertToSnakeCase` (via `SendspinEncoding`),
 /// so we must decode with `.convertFromSnakeCase` to round-trip correctly.
+///
+/// Dispatches on `SendspinEncoding.messageType` — the same wire-tag read the client
+/// uses to route inbound frames — so background `client/time` traffic (which decodes
+/// "successfully" as an empty command) can't be mistaken for the real command.
 private func lastSentCommand(from mock: MockTransport, after offset: Int) async throws -> ClientCommandMessage? {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     let messages = await mock.sentTextMessages
-    return messages.dropFirst(offset).compactMap { data in
-        try? decoder.decode(ClientCommandMessage.self, from: data)
-    }.last
+    return messages.dropFirst(offset)
+        .filter { SendspinEncoding.messageType(of: $0) == "client/command" }
+        .compactMap { try? decoder.decode(ClientCommandMessage.self, from: $0) }
+        .last
 }
 
 /// Drive a competing connection to completion: start `acceptConnection` and,
@@ -256,30 +261,27 @@ private func acceptCompeting(
     return mock
 }
 
-/// Reasons from every `client/goodbye` the client sent on `mock`.
-///
-/// `ClientGoodbyeMessage`'s synthesized decoder overwrites its constant `type`
-/// from the JSON, so other message types decode "successfully" — filter on the
-/// decoded `type` to keep only real goodbyes.
+/// Reasons from every `client/goodbye` the client sent on `mock`, in send order.
 private func sentGoodbyeReasons(from mock: MockTransport) async -> [GoodbyeReason] {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     let messages = await mock.sentTextMessages
     return messages
-        .compactMap { try? decoder.decode(ClientGoodbyeMessage.self, from: $0) }
-        .filter { $0.type == "client/goodbye" }
-        .compactMap { $0.payload?.reason }
+        .filter { SendspinEncoding.messageType(of: $0) == "client/goodbye" }
+        .compactMap { (try? decoder.decode(ClientGoodbyeMessage.self, from: $0))?.payload?.reason }
 }
 
-/// Decode the last `ClientStateMessage` payload sent after `offset`.
+/// Decode the last `client/state` payload sent after `offset`.
 ///
 /// Uses a plain decoder (no snake-case conversion) because the nested
 /// `PlayerStateObject` defines explicit snake_case `CodingKeys`.
 private func lastClientState(from mock: MockTransport, after offset: Int) async -> ClientStatePayload? {
     let messages = await mock.sentTextMessages
-    return messages.dropFirst(offset).compactMap { data in
-        try? JSONDecoder().decode(ClientStateMessage.self, from: data)
-    }.last?.payload
+    return messages.dropFirst(offset)
+        .filter { SendspinEncoding.messageType(of: $0) == "client/state" }
+        .compactMap { try? JSONDecoder().decode(ClientStateMessage.self, from: $0) }
+        .last?
+        .payload
 }
 
 // MARK: - Tests
@@ -712,15 +714,12 @@ struct ClientIntegrationTests {
         let client = try makeTestClient()
         let mock = try await connectClient(client)
 
-        let countBefore = await mock.sentTextMessages.count
         await client.disconnect()
 
-        let messages = await mock.sentTextMessages
-        let goodbye = messages.dropFirst(countBefore).compactMap { data in
-            try? JSONDecoder().decode(ClientGoodbyeMessage.self, from: data)
-        }.last
-        let sent = try #require(goodbye, "Expected a client/goodbye after disconnect()")
-        #expect(sent.payload?.reason == .restart)
+        // Exactly one goodbye, carrying .restart. sentGoodbyeReasons filters on the
+        // decoded `type`, so background client/time traffic can't masquerade as one.
+        let reasons = await sentGoodbyeReasons(from: mock)
+        #expect(reasons == [.restart], "disconnect() must send one client/goodbye with reason .restart")
     }
 
     // MARK: underrun-driven operational state reporting is guarded
@@ -765,9 +764,11 @@ struct ClientIntegrationTests {
         let countBefore = await mock.sentTextMessages.count
         await client.applyUnderrunTransition(.toError)
 
-        // The guard must leave external-source untouched and send nothing.
+        // The guard must leave external-source untouched and send no client/state.
+        // (Asserting on raw message count is wrong: a connected client emits
+        // background client/time traffic that would inflate the count regardless.)
         #expect(client.clientOperationalState == .externalSource)
-        let sentAfter = await mock.sentTextMessages.count
-        #expect(sentAfter == countBefore)
+        let stateAfter = await lastClientState(from: mock, after: countBefore)
+        #expect(stateAfter == nil, "An ignored underrun transition must not send a client/state")
     }
 }

--- a/Tests/SendspinKitTests/Integration/ClientStateDeltaTests.swift
+++ b/Tests/SendspinKitTests/Integration/ClientStateDeltaTests.swift
@@ -5,16 +5,14 @@ import Foundation
 @testable import SendspinKit
 import Testing
 
-/// Decode every `client/state` payload sent after `offset`, filtering on the
-/// JSON `type` field. Necessary because `ClientStatePayload`'s fields are all
-/// optional, so other message types decode "successfully" as an empty payload.
+/// Decode every `client/state` payload sent after `offset`, dispatching on the wire
+/// `type` tag. Necessary because `ClientStatePayload`'s fields are all optional, so
+/// other message types decode "successfully" as an empty payload.
 private func clientStatePayloads(from mock: MockTransport, after offset: Int = 0) async -> [ClientStatePayload] {
     let messages = await mock.sentTextMessages
-    return messages.dropFirst(offset).compactMap { data -> ClientStatePayload? in
-        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              object["type"] as? String == "client/state" else { return nil }
-        return try? JSONDecoder().decode(ClientStateMessage.self, from: data).payload
-    }
+    return messages.dropFirst(offset)
+        .filter { SendspinEncoding.messageType(of: $0) == "client/state" }
+        .compactMap { try? JSONDecoder().decode(ClientStateMessage.self, from: $0).payload }
 }
 
 @MainActor


### PR DESCRIPTION
The ClientIntegrationTests helpers that inspect client-sent messages (lastSentCommand, lastClientState) force-decoded raw bytes as a specific message type without first checking the type. Because every message's `type` is a `let` constant the synthesized decoder leaves untouched and payloads are all-optional, a background client/time (from the clock-sync loop) decodes "successfully" as an empty command/state — so under parallel load a racing client/time got picked as `.last`, intermittently failing setShuffle/setRepeatMode/applyUnderrunTransition and the raw-count external-source guard.

Extract the type-tag read both production sites already inlined (handleTextMessage and the handshake server/hello peek) into SendspinEncoding.messageType(of:), and route every sent-message assertion through it — the same wire-tag dispatch the client uses for inbound frames. The raw sentTextMessages.count assertion becomes a typed "no client/state sent" check.

Verified across 20 consecutive full-suite runs; the flake previously surfaced within ~10.