### PR TITLE
Implement the visualizer@v1 role (aiosendspin 6.x compatibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to SendspinKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Visualizer@v1 role implementation** (previously a placeholder). `SendspinClient`
+  accepts a `visualizerConfig: VisualizerConfiguration` declaring feature types
+  (loudness / beat / f_peak / spectrum / peak / pitch), spectrum binning, buffer
+  capacity, and `rate_max`; the negotiated `stream/start` visualizer announcement
+  surfaces as `ClientEvent.visualizerStreamStarted(StreamVisualizerConfig)` and
+  `currentVisualizerStream`.
+- Binary visualizer frame types 17–21 (beat, f_peak, spectrum, peak, pitch) are now
+  recognized and routed; `VisualizerData` carries the feature `type` and offers a
+  typed `frame(spectrumBins:)` decode into the new `VisualizerFrame` enum.
+- Conformance fixtures for the visualizer role, hand-derived from aiosendspin 6.0.5
+  (`Tests/SendspinKitTests/Models/VisualizerModelTests.swift`).
+
+### Fixed
+- **`client/hello` no longer encodes `visualizer@v1_support` as an empty `{}`** —
+  the shape aiosendspin 6.x hard-rejects, which made advertising the visualizer role
+  break the whole handshake against Music Assistant 2.9.x. The support object is now
+  built from a validated `VisualizerConfiguration`, and constructing a client that
+  advertises `visualizer@v1` without one throws
+  `ConfigurationError.visualizerRoleRequiresConfiguration`.
+
+### Changed
+- `BinaryMessageType.visualizerData` (16) is renamed `.visualizerLoudness` to match
+  the per-feature ID allocation in aiosendspin's `BinaryMessageType` (internal type).
+
 ## [0.3.0] - 2025-10-26
 
 ### Added

--- a/Sources/SendspinKit/Client/ClientTypes.swift
+++ b/Sources/SendspinKit/Client/ClientTypes.swift
@@ -110,10 +110,23 @@ public struct ArtworkData: Sendable, Equatable {
 
 /// Visualizer bytes received from the visualizer stream.
 public struct VisualizerData: Sendable, Equatable {
+    /// Which visualizer feature this frame carries, from the binary type byte (16-21).
+    public let type: VisualizerFeatureType
     /// Raw visualizer payload bytes after the Sendspin binary header.
     public let data: Data
     /// Local absolute display time in microseconds.
     public let localDisplayTime: Int64
+
+    /// Decode the payload into a typed ``VisualizerFrame``.
+    ///
+    /// - Parameter spectrumBins: Negotiated `n_disp_bins`, required to size a
+    ///   spectrum frame — pass `currentVisualizerStream?.spectrum?.nDispBins`
+    ///   (or the value from the ``ClientEvent/visualizerStreamStarted(_:)``
+    ///   announcement). Ignored for non-spectrum types.
+    /// - Returns: The decoded frame, or `nil` if the payload length is wrong for the type.
+    public func frame(spectrumBins: Int = 0) -> VisualizerFrame? {
+        VisualizerFrame(type: type, payload: data, spectrumBins: spectrumBins)
+    }
 }
 
 public enum ClientEvent: Sendable, Equatable {
@@ -137,6 +150,9 @@ public enum ClientEvent: Sendable, Equatable {
     case metadataReceived(TrackMetadata)
     case controllerStateUpdated(ControllerState)
     case artworkStreamStarted([StreamArtworkChannelConfig])
+    /// Server announced a visualizer stream in `stream/start` with the negotiated
+    /// feature set. `config.spectrum?.nDispBins` sizes binary spectrum frames.
+    case visualizerStreamStarted(StreamVisualizerConfig)
     /// Server changed the static delay via `server/command`. The host app should
     /// persist this value and pass it back as `initialStaticDelayMs` on next launch.
     case staticDelayChanged(milliseconds: Int)
@@ -274,11 +290,13 @@ public struct ControllerState: Sendable, Hashable {
     }
 }
 
-/// A role that carries its own independently-negotiated stream and can be the
-/// subject of a `stream/request-format`.
+/// A role that carries its own independently-negotiated stream. `player` and
+/// `artwork` can additionally be the subject of a `stream/request-format`;
+/// the visualizer stream is negotiated once via `client/hello` + `stream/start`.
 public enum StreamRole: String, Sendable, Hashable {
     case player
     case artwork
+    case visualizer
 }
 
 /// Errors thrown by `SendspinClient` methods.

--- a/Sources/SendspinKit/Client/ConnectionEvent.swift
+++ b/Sources/SendspinKit/Client/ConnectionEvent.swift
@@ -23,6 +23,9 @@ enum ConnectionEvent: Equatable {
     /// Artwork stream started with channel configs
     case artworkStreamStarted([StreamArtworkChannelConfig])
 
+    /// Visualizer stream started with the negotiated feature set
+    case visualizerStreamStarted(StreamVisualizerConfig)
+
     /// Audio stream was accepted by the control plane and its format validated.
     case streamAccepted(AudioFormatSpec)
 

--- a/Sources/SendspinKit/Client/SendspinClient+Handshake.swift
+++ b/Sources/SendspinKit/Client/SendspinClient+Handshake.swift
@@ -17,6 +17,19 @@ extension SendspinClient {
             artworkV1Support = ArtworkSupport(channels: artworkConfig.channels)
         }
 
+        // aiosendspin 6.x hard-rejects a client/hello whose visualizer@v1_support
+        // is incomplete (the old empty {} shape breaks the handshake), so the
+        // support object is always built from a validated VisualizerConfiguration.
+        var visualizerV1Support: VisualizerSupport?
+        if roleSet.contains(.visualizerV1), let visualizerConfig {
+            visualizerV1Support = VisualizerSupport(
+                bufferCapacity: visualizerConfig.bufferCapacity,
+                rateMax: visualizerConfig.rateMax,
+                types: visualizerConfig.types,
+                spectrum: visualizerConfig.spectrum
+            )
+        }
+
         return ClientHelloPayload(
             clientId: clientId,
             name: name,
@@ -25,7 +38,7 @@ extension SendspinClient {
             supportedRoles: roles,
             playerV1Support: playerV1Support,
             artworkV1Support: artworkV1Support,
-            visualizerV1Support: roleSet.contains(.visualizerV1) ? VisualizerSupport() : nil
+            visualizerV1Support: visualizerV1Support
         )
     }
 }

--- a/Sources/SendspinKit/Client/SendspinClient.swift
+++ b/Sources/SendspinKit/Client/SendspinClient.swift
@@ -14,6 +14,7 @@ public final class SendspinClient {
     let deviceInfo: DeviceInfo?
     let playerConfig: PlayerConfiguration?
     let artworkConfig: ArtworkConfiguration?
+    let visualizerConfig: VisualizerConfiguration?
     /// Optional storage hook for the spec's "last played server" bookkeeping.
     /// Saved on every `group/update` that reports playback started; read by the
     /// multi-server arbitration tiebreak. `nil` means no implicit storage: discovery
@@ -54,11 +55,13 @@ public final class SendspinClient {
     /// Observability mirrors of server-declared stream activity. These do NOT
     /// gate `stream/request-format`: per spec, those requests are allowed before
     /// a stream starts and after it ends. The mirrors are render-applied (player:
-    /// from the engine's `.started` report; artwork:
-    /// from `.artworkStreamStarted`), so they can lag the connection's gates.
-    /// `stream/clear` leaves both untouched — the stream continues (per spec).
+    /// from the engine's `.started` report; artwork/visualizer:
+    /// from `.artworkStreamStarted`/`.visualizerStreamStarted`), so they can lag
+    /// the connection's gates.
+    /// `stream/clear` leaves them untouched — the stream continues (per spec).
     var playerStreamActive = false
     var artworkStreamActive = false
+    var visualizerStreamActive = false
     /// Cached from `playerConfig?.emitRawAudioEvents` to avoid optional chaining on every audio chunk.
     var shouldEmitRawAudio = false
 
@@ -122,6 +125,11 @@ public final class SendspinClient {
     let visualizerDataContinuation: AsyncStream<VisualizerData>.Continuation
     /// Visualizer bytes from the visualizer data stream.
     public let visualizerData: AsyncStream<VisualizerData>
+    /// The server's negotiated visualizer stream announcement from the most recent
+    /// `stream/start`, or nil if no visualizer stream is active. Its
+    /// `spectrum.nDispBins` is the bin count for decoding binary spectrum frames
+    /// (see ``VisualizerData/frame(spectrumBins:)``).
+    public private(set) var currentVisualizerStream: StreamVisualizerConfig?
 
     public init(
         clientId: String,
@@ -130,6 +138,7 @@ public final class SendspinClient {
         deviceInfo: DeviceInfo? = .current,
         playerConfig: PlayerConfiguration? = nil,
         artworkConfig: ArtworkConfiguration? = nil,
+        visualizerConfig: VisualizerConfiguration? = nil,
         persistenceProvider: (any SendspinPersistenceProvider)? = nil
     ) throws(ConfigurationError) {
         let orderedRoles = Self.deduplicatingRoles(roles)
@@ -141,6 +150,9 @@ public final class SendspinClient {
         if roleSet.contains(.artworkV1), artworkConfig == nil {
             throw .artworkRoleRequiresConfiguration
         }
+        if roleSet.contains(.visualizerV1), visualizerConfig == nil {
+            throw .visualizerRoleRequiresConfiguration
+        }
 
         self.clientId = clientId
         self.name = name
@@ -149,6 +161,7 @@ public final class SendspinClient {
         self.deviceInfo = deviceInfo
         self.playerConfig = playerConfig
         self.artworkConfig = artworkConfig
+        self.visualizerConfig = visualizerConfig
         self.persistenceProvider = persistenceProvider
         staticDelayMs = playerConfig?.initialStaticDelayMs ?? 0
 
@@ -478,6 +491,11 @@ public final class SendspinClient {
             artworkStreamActive = true
             emitEvent(.artworkStreamStarted(channels))
 
+        case let .visualizerStreamStarted(config):
+            visualizerStreamActive = true
+            currentVisualizerStream = config
+            emitEvent(.visualizerStreamStarted(config))
+
         case let .streamAccepted(format):
             playerStreamActive = true
             updateStreamFormat(format)
@@ -500,6 +518,10 @@ public final class SendspinClient {
             }
             if roles == nil || roles?.contains(StreamRole.artwork.rawValue) == true {
                 artworkStreamActive = false
+            }
+            if roles == nil || roles?.contains(StreamRole.visualizer.rawValue) == true {
+                visualizerStreamActive = false
+                currentVisualizerStream = nil
             }
             emitEvent(.streamEnded(roles: roles))
 
@@ -594,6 +616,8 @@ public final class SendspinClient {
         shouldEmitRawAudio = false
         playerStreamActive = false
         artworkStreamActive = false
+        visualizerStreamActive = false
+        currentVisualizerStream = nil
     }
 
     /// Clear server-reported state that is scoped to a single connection. A

--- a/Sources/SendspinKit/Client/SendspinConnection+MessageHandling.swift
+++ b/Sources/SendspinKit/Client/SendspinConnection+MessageHandling.swift
@@ -64,7 +64,8 @@ extension SendspinConnection {
         case .artworkChannel0, .artworkChannel1, .artworkChannel2, .artworkChannel3:
             await handleArtworkBinary(message)
 
-        case .visualizerData:
+        case .visualizerLoudness, .visualizerBeat, .visualizerFPeak,
+             .visualizerSpectrum, .visualizerPeak, .visualizerPitch:
             await handleVisualizerBinary(message)
         }
     }
@@ -190,8 +191,10 @@ extension SendspinConnection {
         }
 
         // Handle visualizer stream
-        if message.payload.visualizer != nil {
+        if let visualizerInfo = message.payload.visualizer {
             visualizerStreamActive = true
+            negotiatedVisualizerStream = visualizerInfo
+            controlSink.enqueue(.visualizerStreamStarted(visualizerInfo))
         }
 
         // Handle player stream
@@ -291,8 +294,9 @@ extension SendspinConnection {
             artworkStreamActive = false
         }
 
-        if endedRoles == nil || endedRoles?.contains("visualizer") == true {
+        if endedRoles == nil || endedRoles?.contains(StreamRole.visualizer.rawValue) == true {
             visualizerStreamActive = false
+            negotiatedVisualizerStream = nil
         }
 
         // Per spec, entering external_source causes the server to end active streams.
@@ -396,6 +400,8 @@ extension SendspinConnection {
     }
 
     func handleVisualizerBinary(_ message: BinaryMessage) async {
+        guard let feature = message.type.visualizerFeature else { return }
+
         guard visualizerStreamActive else {
             Log.client.warning("Discarding visualizer binary: no active visualizer stream")
             return
@@ -407,7 +413,7 @@ extension SendspinConnection {
         }
 
         let localDisplayTime = await clock.serverTimeToLocal(message.timestamp)
-        let visualizerData = VisualizerData(data: message.data, localDisplayTime: localDisplayTime)
+        let visualizerData = VisualizerData(type: feature, data: message.data, localDisplayTime: localDisplayTime)
         validity.yieldIfValid(visualizerData, to: visualizerSink)
     }
 }

--- a/Sources/SendspinKit/Client/SendspinConnection.swift
+++ b/Sources/SendspinKit/Client/SendspinConnection.swift
@@ -63,6 +63,10 @@ actor SendspinConnection {
     var playerStreamActive = false
     var artworkStreamActive = false
     var visualizerStreamActive = false
+    /// The most recent `stream/start` visualizer announcement. Retained across
+    /// `stream/clear` (which flushes buffers without renegotiating); replaced by
+    /// the next announcement; cleared when the visualizer stream ends.
+    var negotiatedVisualizerStream: StreamVisualizerConfig?
     var isClockSynced = false
     var announcedPlayerStream: (format: AudioFormatSpec, codecHeader: Data?)?
     var clientOperationalState: ClientOperationalState = .synchronized

--- a/Sources/SendspinKit/Client/VisualizerConfiguration.swift
+++ b/Sources/SendspinKit/Client/VisualizerConfiguration.swift
@@ -1,0 +1,54 @@
+/// Configuration for the visualizer role, provided when creating a ``SendspinClient``.
+///
+/// Declares which visualizer feature types the client wants and how fast the server
+/// may send them. Encoded into `client/hello` as the `visualizer@v1_support` object,
+/// which aiosendspin 6.x validates strictly — an incomplete (or empty) support object
+/// is hard-rejected and the connection fails during the handshake, which is why the
+/// role cannot be advertised without this configuration.
+///
+/// This is a client-side configuration container, not a wire type — it is not `Codable`.
+/// The wire encoding is the internal `VisualizerSupport` hello struct.
+public struct VisualizerConfiguration: Sendable, Hashable {
+    /// Default `rate_max` (Hz per feature type).
+    ///
+    /// Deliberately conservative: the server multiplies this by the number of active
+    /// feature types, and frames for the whole audio write-ahead window are queued
+    /// per-role on the server. Against aiosendspin (4096-slot per-role queue), 5 types
+    /// × 60 Hz = 300 frames/s overflows the queue once the write-ahead exceeds ~13.6 s
+    /// — which a 2 MB player `buffer_capacity` reaches on well-compressed FLAC — and
+    /// the server then disconnects the client ("Role queue full for visualizer").
+    /// 30 Hz keeps a 5-type client safe past 27 s of write-ahead.
+    public static let defaultRateMax = 30
+
+    /// Default `buffer_capacity` in bytes of visualizer frames the client can hold.
+    public static let defaultBufferCapacity = 1_000_000
+
+    /// Feature types to advertise (non-empty). The server intersects these with
+    /// what it can produce and announces the active set in `stream/start`.
+    public let types: [VisualizerFeatureType]
+    /// Spectrum binning to request; required when ``types`` contains `.spectrum`.
+    public let spectrum: VisualizerSpectrumConfig?
+    /// How many bytes of visualizer frames the client can buffer.
+    public let bufferCapacity: Int
+    /// Maximum per-feature frame rate in Hz the server may send.
+    public let rateMax: Int
+
+    public init(
+        types: [VisualizerFeatureType],
+        spectrum: VisualizerSpectrumConfig? = nil,
+        bufferCapacity: Int = Self.defaultBufferCapacity,
+        rateMax: Int = Self.defaultRateMax
+    ) throws(ConfigurationError) {
+        // Mirrors aiosendspin's ClientHelloVisualizerSupport validation
+        // (models/visualizer.py): non-empty types, positive buffer_capacity and
+        // rate_max, spectrum required when "spectrum" is in types.
+        guard !types.isEmpty else { throw .emptyVisualizerTypes }
+        guard bufferCapacity > 0 else { throw .nonPositiveVisualizerBufferCapacity(bufferCapacity) }
+        guard rateMax > 0 else { throw .nonPositiveVisualizerRateMax(rateMax) }
+        guard !types.contains(.spectrum) || spectrum != nil else { throw .spectrumConfigurationRequired }
+        self.types = types
+        self.spectrum = spectrum
+        self.bufferCapacity = bufferCapacity
+        self.rateMax = rateMax
+    }
+}

--- a/Sources/SendspinKit/ConfigurationError.swift
+++ b/Sources/SendspinKit/ConfigurationError.swift
@@ -42,6 +42,21 @@ public enum ConfigurationError: SendspinError, Hashable {
     /// Artwork channel index must be 0–3.
     case artworkChannelOutOfRange(Int)
 
+    // MARK: - VisualizerConfiguration / VisualizerSpectrumConfig
+
+    /// At least one visualizer feature type is required.
+    case emptyVisualizerTypes
+    /// Visualizer buffer capacity must be positive.
+    case nonPositiveVisualizerBufferCapacity(Int)
+    /// Visualizer rate_max must be positive.
+    case nonPositiveVisualizerRateMax(Int)
+    /// Advertising the `spectrum` feature requires a spectrum configuration.
+    case spectrumConfigurationRequired
+    /// Spectrum display bin count must be positive.
+    case nonPositiveSpectrumBins(Int)
+    /// Spectrum frequency range must satisfy 0 <= f_min < f_max.
+    case invalidSpectrumFrequencyRange(fMin: Int, fMax: Int)
+
     // MARK: - PlayerStateObject
 
     /// Volume must be between 0 and 100.
@@ -61,6 +76,10 @@ public enum ConfigurationError: SendspinError, Hashable {
     case playerRoleRequiresConfiguration
     /// Artwork role was requested but no ``ArtworkConfiguration`` was provided.
     case artworkRoleRequiresConfiguration
+    /// Visualizer role was requested but no ``VisualizerConfiguration`` was provided.
+    /// aiosendspin 6.x hard-rejects a `client/hello` that advertises `visualizer@v1`
+    /// without a complete support object, so the role cannot be advertised bare.
+    case visualizerRoleRequiresConfiguration
 }
 
 extension ConfigurationError: LocalizedError {
@@ -92,6 +111,18 @@ extension ConfigurationError: LocalizedError {
             "\(field) must be non-negative, got \(value)"
         case let .artworkChannelOutOfRange(v):
             "Artwork channel must be 0–3, got \(v)"
+        case .emptyVisualizerTypes:
+            "Must advertise at least one visualizer feature type"
+        case let .nonPositiveVisualizerBufferCapacity(v):
+            "Visualizer buffer capacity must be positive, got \(v)"
+        case let .nonPositiveVisualizerRateMax(v):
+            "Visualizer rate_max must be positive, got \(v)"
+        case .spectrumConfigurationRequired:
+            "Advertising the spectrum feature requires a VisualizerSpectrumConfig"
+        case let .nonPositiveSpectrumBins(v):
+            "Spectrum n_disp_bins must be positive, got \(v)"
+        case let .invalidSpectrumFrequencyRange(fMin, fMax):
+            "Spectrum frequency range must satisfy 0 <= f_min < f_max, got f_min \(fMin), f_max \(fMax)"
         case let .volumeOutOfRange(v):
             "Volume must be 0–100, got \(v)"
         case let .invalidStateCommands(v):
@@ -102,6 +133,8 @@ extension ConfigurationError: LocalizedError {
             "Player role requires a PlayerConfiguration"
         case .artworkRoleRequiresConfiguration:
             "Artwork role requires an ArtworkConfiguration"
+        case .visualizerRoleRequiresConfiguration:
+            "Visualizer role requires a VisualizerConfiguration"
         }
     }
 }

--- a/Sources/SendspinKit/Models/BinaryMessage.swift
+++ b/Sources/SendspinKit/Models/BinaryMessage.swift
@@ -18,8 +18,14 @@ enum BinaryMessageType: UInt8 {
     case artworkChannel2 = 10
     case artworkChannel3 = 11
 
-    /// Visualizer role (16-23).
-    case visualizerData = 16
+    // Visualizer role (16-23), one type per feature
+    // (aiosendspin models/types.py BinaryMessageType)
+    case visualizerLoudness = 16
+    case visualizerBeat = 17
+    case visualizerFPeak = 18
+    case visualizerSpectrum = 19
+    case visualizerPeak = 20
+    case visualizerPitch = 21
 
     /// The artwork channel index (0-3) for artwork message types, or `nil` for non-artwork types.
     var artworkChannel: Int? {
@@ -28,6 +34,19 @@ enum BinaryMessageType: UInt8 {
             Int(rawValue - BinaryMessageType.artworkChannel0.rawValue)
         default:
             nil
+        }
+    }
+
+    /// The visualizer feature this binary type carries, or `nil` for non-visualizer types.
+    var visualizerFeature: VisualizerFeatureType? {
+        switch self {
+        case .visualizerLoudness: .loudness
+        case .visualizerBeat: .beat
+        case .visualizerFPeak: .fPeak
+        case .visualizerSpectrum: .spectrum
+        case .visualizerPeak: .peak
+        case .visualizerPitch: .pitch
+        case .audioChunk, .artworkChannel0, .artworkChannel1, .artworkChannel2, .artworkChannel3: nil
         }
     }
 }

--- a/Sources/SendspinKit/Models/HelloMessages.swift
+++ b/Sources/SendspinKit/Models/HelloMessages.swift
@@ -120,15 +120,29 @@ struct ArtworkSupport: Codable, Equatable {
     let channels: [ArtworkChannel]
 }
 
-/// Empty `supported.visualizer` block. The visualizer role is not yet
-/// implemented; this exists so a server payload advertising visualizer support
-/// decodes (and re-encodes) without error rather than failing the whole message.
+/// Visualizer@v1 support object in client/hello per spec
+/// (aiosendspin models/visualizer.py `ClientHelloVisualizerSupport`).
+///
+/// aiosendspin 6.x validates this object strictly on the server side —
+/// non-empty `types`, positive `buffer_capacity`/`rate_max`, and a `spectrum`
+/// object whenever `"spectrum"` is in `types` — and hard-rejects the whole
+/// `client/hello` otherwise. In particular the empty `{}` shape this struct
+/// used to encode is rejected, so advertising the visualizer role without a
+/// complete support object breaks the connection during the handshake.
+/// Validation of client input lives in ``VisualizerConfiguration``; this wire
+/// struct carries already-validated fields.
 struct VisualizerSupport: Codable, Equatable {
-    init() {}
+    let bufferCapacity: Int
+    let rateMax: Int
+    let types: [VisualizerFeatureType]
+    let spectrum: VisualizerSpectrumConfig?
 
-    // Explicit Codable implementation for empty struct
-    init(from _: Decoder) throws {}
-    func encode(to _: Encoder) throws {}
+    enum CodingKeys: String, CodingKey {
+        case bufferCapacity = "buffer_capacity"
+        case rateMax = "rate_max"
+        case types
+        case spectrum
+    }
 }
 
 // MARK: - Server Messages

--- a/Sources/SendspinKit/Models/StreamMessages.swift
+++ b/Sources/SendspinKit/Models/StreamMessages.swift
@@ -14,7 +14,7 @@ struct StreamStartMessage: SendspinMessage, Equatable {
 struct StreamStartPayload: Codable, Equatable {
     let player: StreamStartPlayer?
     let artwork: StreamStartArtwork?
-    let visualizer: StreamStartVisualizer?
+    let visualizer: StreamVisualizerConfig?
 }
 
 /// Player stream configuration within stream/start.
@@ -44,17 +44,6 @@ struct StreamStartPlayer: Codable, Equatable {
 struct StreamStartArtwork: Codable, Equatable {
     /// Configuration for each active artwork channel, array index is the channel number
     let channels: [StreamArtworkChannelConfig]
-}
-
-/// Empty `stream/start` visualizer block. The visualizer role is not yet
-/// implemented; this exists so a server `stream/start` carrying a visualizer
-/// block decodes (and re-encodes) without error rather than failing the message.
-struct StreamStartVisualizer: Codable, Equatable {
-    init() {}
-
-    // Explicit Codable implementation for empty struct
-    init(from _: Decoder) throws {}
-    func encode(to _: Encoder) throws {}
 }
 
 /// Stream end message — ends streams for specified roles (or all if omitted)

--- a/Sources/SendspinKit/Models/VisualizerModels.swift
+++ b/Sources/SendspinKit/Models/VisualizerModels.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+// MARK: - Visualizer feature vocabulary
+
+/// Visualizer feature types negotiable via the visualizer role, per spec.
+///
+/// The client advertises a subset in `client/hello`'s `visualizer@v1_support.types`;
+/// the server intersects that with what it can produce and announces the active
+/// set in `stream/start`'s `visualizer.types`.
+///
+/// Raw values match the aiosendspin wire strings (models/visualizer.py `VisualizerType`).
+public enum VisualizerFeatureType: String, Codable, Sendable, Hashable, CaseIterable {
+    /// Perceptual loudness, one u16 per frame (binary type 16).
+    case loudness
+    /// Beat markers with a downbeat flag (binary type 17).
+    case beat
+    /// Dominant frequency + amplitude (binary type 18).
+    case fPeak = "f_peak"
+    /// Display-binned spectrum, `n_disp_bins` × u16 (binary type 19).
+    case spectrum
+    /// Energy-onset strength (binary type 20).
+    case peak
+    /// Perceived pitch as MIDI note + confidence (binary type 21).
+    case pitch
+}
+
+/// Spectrum binning scale (aiosendspin models/visualizer.py `SpectrumScale`).
+public enum SpectrumScale: String, Codable, Sendable, Hashable {
+    /// Linear frequency binning.
+    case lin
+    /// Logarithmic frequency binning.
+    case log
+    /// Mel-scale (perceptual) frequency binning.
+    case mel
+}
+
+/// Spectrum configuration, required when ``VisualizerFeatureType/spectrum`` is advertised.
+///
+/// Appears in two places on the wire: the client's `visualizer@v1_support.spectrum`
+/// (validated client input — use ``init(nDispBins:scale:fMin:fMax:)``) and the server's
+/// negotiated `stream/start.visualizer.spectrum` (server-provided values, decoded
+/// without validation like other server payloads — treat as untrusted informational
+/// metadata and sanity-check before relying on them).
+public struct VisualizerSpectrumConfig: Codable, Sendable, Hashable {
+    /// Number of display bins in each binary spectrum frame. Drives the expected
+    /// payload size of binary type 19 frames (`nDispBins` × 2 bytes).
+    public let nDispBins: Int
+    /// Frequency binning scale.
+    public let scale: SpectrumScale
+    /// Lower frequency bound in Hz.
+    public let fMin: Int
+    /// Upper frequency bound in Hz.
+    public let fMax: Int
+
+    enum CodingKeys: String, CodingKey {
+        case nDispBins = "n_disp_bins"
+        case scale
+        case fMin = "f_min"
+        case fMax = "f_max"
+    }
+
+    /// Create a validated spectrum configuration for `client/hello`.
+    ///
+    /// Mirrors aiosendspin's `ClientHelloVisualizerSpectrum` validation
+    /// (models/visualizer.py): positive bin count and a non-inverted, non-negative
+    /// frequency range.
+    public init(nDispBins: Int, scale: SpectrumScale, fMin: Int, fMax: Int) throws(ConfigurationError) {
+        guard nDispBins > 0 else { throw .nonPositiveSpectrumBins(nDispBins) }
+        guard fMin >= 0, fMax > fMin else { throw .invalidSpectrumFrequencyRange(fMin: fMin, fMax: fMax) }
+        self.nDispBins = nDispBins
+        self.scale = scale
+        self.fMin = fMin
+        self.fMax = fMax
+    }
+}
+
+// MARK: - Negotiated stream/start visualizer object
+
+/// The server's negotiated visualizer stream announcement in `stream/start`
+/// (aiosendspin models/visualizer.py `StreamStartVisualizer`).
+///
+/// Decoding is deliberately tolerant: `stream/start` is one message carrying the
+/// player, artwork, AND visualizer sections, so a malformed or forward-incompatible
+/// visualizer block must not fail the whole decode and silence audio. Unknown
+/// feature strings are dropped from ``types``; missing fields decode to safe
+/// defaults. Values are server-provided informational metadata — no validation
+/// beyond `Decodable`.
+public struct StreamVisualizerConfig: Codable, Sendable, Hashable {
+    /// Active feature types the server will stream (unknown wire strings are dropped).
+    public let types: [VisualizerFeatureType]
+    /// Maximum per-feature frame rate in Hz the server will send (0 if absent/malformed).
+    public let rateMax: Int
+    /// Whether beat frames distinguish downbeats, when the server reports it.
+    public let tracksDownbeats: Bool?
+    /// Negotiated spectrum binning, present when ``types`` contains `.spectrum`.
+    /// `spectrum.nDispBins` sizes binary spectrum frames (see ``VisualizerFrame``).
+    public let spectrum: VisualizerSpectrumConfig?
+
+    enum CodingKeys: String, CodingKey {
+        case types
+        case rateMax = "rate_max"
+        case tracksDownbeats = "tracks_downbeats"
+        case spectrum
+    }
+
+    public init(
+        types: [VisualizerFeatureType],
+        rateMax: Int,
+        tracksDownbeats: Bool? = nil,
+        spectrum: VisualizerSpectrumConfig? = nil
+    ) {
+        self.types = types
+        self.rateMax = rateMax
+        self.tracksDownbeats = tracksDownbeats
+        self.spectrum = spectrum
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Tolerate unknown/newer feature strings by dropping them rather than
+        // failing the whole stream/start decode.
+        let rawTypes = (try? container.decode([String].self, forKey: .types)) ?? []
+        types = rawTypes.compactMap(VisualizerFeatureType.init(rawValue:))
+        rateMax = (try? container.decode(Int.self, forKey: .rateMax)) ?? 0
+        tracksDownbeats = try? container.decodeIfPresent(Bool.self, forKey: .tracksDownbeats)
+        spectrum = try? container.decodeIfPresent(VisualizerSpectrumConfig.self, forKey: .spectrum)
+    }
+}
+
+// MARK: - Binary visualizer frames
+
+/// A decoded visualizer feature frame from binary types 16–21
+/// (aiosendspin server/roles/visualizer/v1.py wire packing, all big-endian).
+///
+/// On the v1 wire each binary message carries exactly one feature, so this is an
+/// enum, not a struct of optionals. Values are the raw unsigned integers from the
+/// wire; scaling to display units is the consumer's concern.
+public enum VisualizerFrame: Sendable, Hashable {
+    /// Perceptual loudness (u16) — binary type 16.
+    case loudness(UInt16)
+    /// Beat marker; `isDownbeat` is bit 0 of the flags byte — binary type 17.
+    case beat(isDownbeat: Bool)
+    /// Dominant frequency in Hz + amplitude (u16 each) — binary type 18.
+    /// `frequencyHz == 0` implies `amplitude == 0`.
+    case fPeak(frequencyHz: UInt16, amplitude: UInt16)
+    /// Display-binned spectrum, one u16 per negotiated bin — binary type 19.
+    case spectrum([UInt16])
+    /// Energy-onset strength (u8) — binary type 20.
+    case peak(strength: UInt8)
+    /// Perceived pitch as MIDI note in Q8.8 fixed point + confidence (u8) — binary type 21.
+    case pitch(midiQ88: UInt16, confidence: UInt8)
+
+    /// Decode a frame body for the given feature type.
+    ///
+    /// - Parameters:
+    ///   - type: Which feature the payload encodes (from the binary message type byte).
+    ///   - payload: The frame body after the 9-byte Sendspin binary header.
+    ///   - spectrumBins: Negotiated `n_disp_bins`, required to size a spectrum frame.
+    ///     Pass the value from the `stream/start.visualizer.spectrum` announcement
+    ///     (or the client's own hello support config). Ignored for other types.
+    /// - Returns: The decoded frame, or `nil` if the payload length is wrong for the type.
+    public init?(type: VisualizerFeatureType, payload: Data, spectrumBins: Int = 0) {
+        switch type {
+        case .loudness:
+            // v1.py — struct.pack(">H", loudness).
+            guard payload.count == 2 else { return nil }
+            self = .loudness(Self.readUInt16(payload, at: payload.startIndex))
+        case .beat:
+            // v1.py — a single flags byte; bit 0 = downbeat.
+            guard payload.count == 1 else { return nil }
+            self = .beat(isDownbeat: (payload[payload.startIndex] & 0b0000_0001) != 0)
+        case .fPeak:
+            // v1.py — struct.pack(">HH", freq, amp).
+            guard payload.count == 4 else { return nil }
+            self = .fPeak(
+                frequencyHz: Self.readUInt16(payload, at: payload.startIndex),
+                amplitude: Self.readUInt16(payload, at: payload.startIndex + 2)
+            )
+        case .spectrum:
+            // v1.py — spectrum.astype(">u2"), n_disp_bins values.
+            guard spectrumBins > 0, payload.count == spectrumBins * 2 else { return nil }
+            var bins = [UInt16]()
+            bins.reserveCapacity(spectrumBins)
+            var index = payload.startIndex
+            for _ in 0 ..< spectrumBins {
+                bins.append(Self.readUInt16(payload, at: index))
+                index += 2
+            }
+            self = .spectrum(bins)
+        case .peak:
+            // v1.py — one u8 strength byte.
+            guard payload.count == 1 else { return nil }
+            self = .peak(strength: payload[payload.startIndex])
+        case .pitch:
+            // v1.py — struct.pack(">H", midi_q88) + confidence byte.
+            guard payload.count == 3 else { return nil }
+            self = .pitch(
+                midiQ88: Self.readUInt16(payload, at: payload.startIndex),
+                confidence: payload[payload.startIndex + 2]
+            )
+        }
+    }
+
+    /// Read a big-endian u16 at the given absolute index within `data`.
+    private static func readUInt16(_ data: Data, at index: Data.Index) -> UInt16 {
+        (UInt16(data[index]) << 8) | UInt16(data[index + 1])
+    }
+}

--- a/Tests/SendspinKitTests/Integration/BinaryMessageIntegrationTests.swift
+++ b/Tests/SendspinKitTests/Integration/BinaryMessageIntegrationTests.swift
@@ -199,7 +199,7 @@ struct BinaryMessageIntegrationTests {
 
         // Create visualizer message
         var messageData = Data()
-        messageData.append(BinaryMessageType.visualizerData.rawValue)
+        messageData.append(BinaryMessageType.visualizerSpectrum.rawValue)
 
         let timestamp: Int64 = 3_000_000
         withUnsafeBytes(of: timestamp.bigEndian) { messageData.append(contentsOf: $0) }
@@ -209,7 +209,7 @@ struct BinaryMessageIntegrationTests {
         // Decode
         let message = try #require(BinaryMessage(data: messageData))
 
-        #expect(message.type == .visualizerData)
+        #expect(message.type == .visualizerSpectrum)
         #expect(message.timestamp == 3_000_000)
         #expect(message.data.count == binCount * 4) // 32 bins * 4 bytes per float
     }

--- a/Tests/SendspinKitTests/Integration/FrameOrderingTests.swift
+++ b/Tests/SendspinKitTests/Integration/FrameOrderingTests.swift
@@ -30,7 +30,7 @@ private func artworkFrame(
 /// Build a binary `visualizer` frame (type byte + big-endian timestamp + visualizer data).
 private func visualizerFrame(index: Int = 0, baseTimestamp: Int64 = 1_000_000) -> Data {
     var frame = Data()
-    frame.append(BinaryMessageType.visualizerData.rawValue)
+    frame.append(BinaryMessageType.visualizerLoudness.rawValue)
     var timestamp = (baseTimestamp + Int64(index) * 25_000).bigEndian
     frame.append(Data(bytes: &timestamp, count: 8))
     frame.append(Data(repeating: 0xAB, count: 64)) // Dummy visualizer data
@@ -68,7 +68,7 @@ private func streamStartWithVisualizerJSON() throws -> String {
         payload: StreamStartPayload(
             player: nil,
             artwork: nil,
-            visualizer: StreamStartVisualizer()
+            visualizer: StreamVisualizerConfig(types: [.loudness], rateMax: 30)
         )
     )
     let data = try JSONEncoder().encode(message)

--- a/Tests/SendspinKitTests/Models/BinaryMessageTests.swift
+++ b/Tests/SendspinKitTests/Models/BinaryMessageTests.swift
@@ -68,14 +68,14 @@ struct BinaryMessageTests {
     func decodeVisualizerDataMessage() throws {
         let fftData = Data([0x10, 0x20, 0x30, 0x40])
         let frame = Self.makeFrame(
-            type: BinaryMessageType.visualizerData.rawValue,
+            type: BinaryMessageType.visualizerLoudness.rawValue,
             timestamp: 5_000_000,
             payload: fftData
         )
 
         let message = try #require(BinaryMessage(data: frame))
 
-        #expect(message.type == .visualizerData)
+        #expect(message.type == .visualizerLoudness)
         #expect(message.timestamp == 5_000_000)
         #expect(message.data == fftData)
     }
@@ -105,7 +105,7 @@ struct BinaryMessageTests {
     @Test
     func artworkChannel_returnsNilForNonArtworkTypes() {
         #expect(BinaryMessageType.audioChunk.artworkChannel == nil)
-        #expect(BinaryMessageType.visualizerData.artworkChannel == nil)
+        #expect(BinaryMessageType.visualizerLoudness.artworkChannel == nil)
     }
 
     // MARK: - Timestamp edge cases

--- a/Tests/SendspinKitTests/Models/VisualizerModelTests.swift
+++ b/Tests/SendspinKitTests/Models/VisualizerModelTests.swift
@@ -1,0 +1,278 @@
+// Conformance fixtures for the visualizer@v1 role, hand-derived from the
+// aiosendspin 6.0.5 reference implementation (Music Assistant 2.9.x):
+//   models/visualizer.py — ClientHelloVisualizerSupport, ClientHelloVisualizerSpectrum,
+//                          StreamStartVisualizer, VisualizerType, SpectrumScale
+//   models/types.py      — BinaryMessageType 16-21, BINARY_HEADER_FORMAT ">Bq"
+//   server/roles/visualizer/v1.py — per-feature binary payload packing
+//
+// The hello fixtures are the regression guard for the "empty support object"
+// outage: aiosendspin 6.x hard-rejects a client/hello whose visualizer@v1_support
+// is `{}`, so the encoded object must always carry every validated field.
+
+import Foundation
+@testable import SendspinKit
+import Testing
+
+struct VisualizerModelTests {
+    // MARK: - Helpers
+
+    private func encodeToObject(_ message: some Encodable) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(message)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, _ json: String) throws -> T {
+        let data = try #require(json.data(using: .utf8))
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    /// Build a `[type:1][timestamp:8 big-endian][payload]` binary frame
+    /// (aiosendspin BINARY_HEADER_FORMAT ">Bq").
+    private func binaryFrame(_ type: BinaryMessageType, timestamp: Int64, payload: [UInt8]) -> Data {
+        var data = Data([type.rawValue])
+        withUnsafeBytes(of: timestamp.bigEndian) { data.append(contentsOf: $0) }
+        data.append(contentsOf: payload)
+        return data
+    }
+
+    // MARK: - client/hello visualizer@v1_support (models/visualizer.py ClientHelloVisualizerSupport)
+
+    @Test
+    func clientHello_visualizerSupportIsAFullObjectNeverEmpty() throws {
+        // ClientHelloVisualizerSupport requires buffer_capacity > 0, rate_max > 0,
+        // non-empty types, and a spectrum object when "spectrum" is in types
+        // (ClientHelloVisualizerSpectrum). An empty {} is rejected with the whole hello.
+        let payload = try ClientHelloPayload(
+            clientId: "test-visualizer",
+            name: "Test Visualizer",
+            deviceInfo: nil,
+            version: 1,
+            supportedRoles: [.visualizerV1],
+            playerV1Support: nil,
+            artworkV1Support: nil,
+            visualizerV1Support: VisualizerSupport(
+                bufferCapacity: 1_000_000,
+                rateMax: 30,
+                types: [.loudness, .spectrum, .beat],
+                spectrum: VisualizerSpectrumConfig(nDispBins: 48, scale: .log, fMin: 40, fMax: 16_000)
+            )
+        )
+        let obj = try encodeToObject(ClientHelloMessage(payload: payload))
+        let payloadObj = try #require(obj["payload"] as? [String: Any])
+
+        #expect((payloadObj["supported_roles"] as? [String])?.contains("visualizer@v1") == true)
+        let support = try #require(payloadObj["visualizer@v1_support"] as? [String: Any])
+        // The exact fields aiosendspin 6.x validates; the rejected empty-{} shape must never occur.
+        #expect(!support.isEmpty)
+        #expect(support["buffer_capacity"] as? Int == 1_000_000)
+        #expect(support["rate_max"] as? Int == 30)
+        #expect(support["types"] as? [String] == ["loudness", "spectrum", "beat"])
+        let spectrum = try #require(support["spectrum"] as? [String: Any])
+        #expect(spectrum["n_disp_bins"] as? Int == 48)
+        #expect(spectrum["scale"] as? String == "log")
+        #expect(spectrum["f_min"] as? Int == 40)
+        #expect(spectrum["f_max"] as? Int == 16_000)
+    }
+
+    @Test
+    func clientHello_spectrumlessSupportOmitsSpectrumKey() throws {
+        let payload = ClientHelloPayload(
+            clientId: "test-visualizer",
+            name: "Test Visualizer",
+            deviceInfo: nil,
+            version: 1,
+            supportedRoles: [.visualizerV1],
+            playerV1Support: nil,
+            artworkV1Support: nil,
+            visualizerV1Support: VisualizerSupport(
+                bufferCapacity: VisualizerConfiguration.defaultBufferCapacity,
+                rateMax: VisualizerConfiguration.defaultRateMax,
+                types: [.loudness],
+                spectrum: nil
+            )
+        )
+        let obj = try encodeToObject(ClientHelloMessage(payload: payload))
+        let payloadObj = try #require(obj["payload"] as? [String: Any])
+        let support = try #require(payloadObj["visualizer@v1_support"] as? [String: Any])
+        // Absent spectrum must be an omitted key, not an explicit null.
+        #expect(support.keys.contains("spectrum") == false)
+    }
+
+    @Test
+    @MainActor
+    func clientFacade_buildsFullVisualizerSupportFromConfiguration() throws {
+        let client = try SendspinClient(
+            clientId: "test-visualizer",
+            name: "Test Visualizer",
+            roles: [.visualizerV1],
+            visualizerConfig: VisualizerConfiguration(
+                types: [.loudness, .spectrum],
+                spectrum: VisualizerSpectrumConfig(nDispBins: 64, scale: .mel, fMin: 20, fMax: 20_000)
+            )
+        )
+        let hello = client.buildClientHelloPayload()
+        let support = try #require(hello.visualizerV1Support)
+        #expect(support.bufferCapacity == VisualizerConfiguration.defaultBufferCapacity)
+        #expect(support.rateMax == VisualizerConfiguration.defaultRateMax)
+        #expect(support.types == [.loudness, .spectrum])
+        #expect(support.spectrum?.nDispBins == 64)
+    }
+
+    @Test
+    @MainActor
+    func visualizerRole_requiresConfiguration() {
+        #expect(throws: ConfigurationError.visualizerRoleRequiresConfiguration) {
+            _ = try SendspinClient(
+                clientId: "test-visualizer",
+                name: "Test Visualizer",
+                roles: [.visualizerV1]
+            )
+        }
+    }
+
+    // MARK: - VisualizerConfiguration validation (mirrors ClientHelloVisualizerSupport)
+
+    @Test
+    func configuration_rejectsInvalidInput() throws {
+        #expect(throws: ConfigurationError.emptyVisualizerTypes) {
+            _ = try VisualizerConfiguration(types: [])
+        }
+        #expect(throws: ConfigurationError.nonPositiveVisualizerBufferCapacity(0)) {
+            _ = try VisualizerConfiguration(types: [.loudness], bufferCapacity: 0)
+        }
+        #expect(throws: ConfigurationError.nonPositiveVisualizerRateMax(-1)) {
+            _ = try VisualizerConfiguration(types: [.loudness], rateMax: -1)
+        }
+        // "spectrum" in types requires a spectrum config.
+        #expect(throws: ConfigurationError.spectrumConfigurationRequired) {
+            _ = try VisualizerConfiguration(types: [.loudness, .spectrum])
+        }
+        #expect(throws: ConfigurationError.nonPositiveSpectrumBins(0)) {
+            _ = try VisualizerSpectrumConfig(nDispBins: 0, scale: .log, fMin: 40, fMax: 16_000)
+        }
+        #expect(throws: ConfigurationError.invalidSpectrumFrequencyRange(fMin: 100, fMax: 100)) {
+            _ = try VisualizerSpectrumConfig(nDispBins: 48, scale: .log, fMin: 100, fMax: 100)
+        }
+    }
+
+    // MARK: - stream/start visualizer (models/visualizer.py StreamStartVisualizer)
+
+    @Test
+    func streamStart_withPlayerAndVisualizerSectionsDecodes() throws {
+        let json = """
+        {
+          "type": "stream/start",
+          "payload": {
+            "player": {"codec": "flac", "sample_rate": 48000, "channels": 2, "bit_depth": 24, "codec_header": "ZkxhQw=="},
+            "visualizer": {"types": ["loudness", "spectrum", "beat"], "rate_max": 60, "tracks_downbeats": true,
+                           "spectrum": {"n_disp_bins": 48, "scale": "log", "f_min": 40, "f_max": 16000}}
+          }
+        }
+        """
+        let message = try decode(StreamStartMessage.self, json)
+        let player = try #require(message.payload.player)
+        #expect(player.codec == "flac")
+
+        let visualizer = try #require(message.payload.visualizer)
+        #expect(visualizer.types == [.loudness, .spectrum, .beat])
+        #expect(visualizer.rateMax == 60)
+        #expect(visualizer.tracksDownbeats == true)
+        #expect(visualizer.spectrum?.nDispBins == 48)
+        #expect(visualizer.spectrum?.scale == .log)
+    }
+
+    @Test
+    func streamStart_visualizerDropsUnknownFeatureStringsWithoutFailing() throws {
+        // A newer server may stream feature types this client doesn't know.
+        // They must be dropped — not fail the whole stream/start (which would
+        // also kill the player section and silence audio).
+        let json = """
+        {"type": "stream/start", "payload": {"visualizer": {"types": ["loudness", "chroma"], "rate_max": 30}}}
+        """
+        let message = try decode(StreamStartMessage.self, json)
+        #expect(message.payload.visualizer?.types == [.loudness])
+        #expect(message.payload.visualizer?.rateMax == 30)
+        #expect(message.payload.player == nil)
+    }
+
+    // MARK: - Binary visualizer frames (models/types.py 16-21, server/roles/visualizer/v1.py packing)
+
+    @Test
+    func binaryTypes_coverTheVisualizerRange() {
+        // models/types.py BinaryMessageType: one ID per feature in 16-21.
+        #expect(BinaryMessageType.visualizerLoudness.rawValue == 16)
+        #expect(BinaryMessageType.visualizerBeat.rawValue == 17)
+        #expect(BinaryMessageType.visualizerFPeak.rawValue == 18)
+        #expect(BinaryMessageType.visualizerSpectrum.rawValue == 19)
+        #expect(BinaryMessageType.visualizerPeak.rawValue == 20)
+        #expect(BinaryMessageType.visualizerPitch.rawValue == 21)
+
+        #expect(BinaryMessageType.visualizerBeat.visualizerFeature == .beat)
+        #expect(BinaryMessageType.audioChunk.visualizerFeature == nil)
+        #expect(BinaryMessageType.artworkChannel0.visualizerFeature == nil)
+    }
+
+    @Test
+    func binaryLoudnessFrame_decodesAU16() throws {
+        // v1.py — struct.pack(">H", loudness).
+        let message = try #require(BinaryMessage(data: binaryFrame(.visualizerLoudness, timestamp: 5_000_000, payload: [0x12, 0x34])))
+        #expect(message.type == .visualizerLoudness)
+        #expect(message.timestamp == 5_000_000)
+        let frame = try #require(VisualizerFrame(type: .loudness, payload: message.data))
+        #expect(frame == .loudness(0x1234))
+    }
+
+    @Test
+    func binaryBeatFrame_decodesTheDownbeatFlag() throws {
+        // v1.py — one flags byte; bit 0 = downbeat.
+        let downbeat = try #require(BinaryMessage(data: binaryFrame(.visualizerBeat, timestamp: 1, payload: [0x01])))
+        #expect(VisualizerFrame(type: .beat, payload: downbeat.data) == .beat(isDownbeat: true))
+        let offbeat = try #require(BinaryMessage(data: binaryFrame(.visualizerBeat, timestamp: 2, payload: [0x00])))
+        #expect(VisualizerFrame(type: .beat, payload: offbeat.data) == .beat(isDownbeat: false))
+    }
+
+    @Test
+    func binaryFPeakFrame_decodesFrequencyAndAmplitude() throws {
+        // v1.py — struct.pack(">HH", freq, amp).
+        let message = try #require(BinaryMessage(data: binaryFrame(.visualizerFPeak, timestamp: 3, payload: [0x01, 0x00, 0x00, 0xFF])))
+        #expect(VisualizerFrame(type: .fPeak, payload: message.data) == .fPeak(frequencyHz: 256, amplitude: 255))
+    }
+
+    @Test
+    func binarySpectrumFrame_decodesNegotiatedBinCountU16Values() throws {
+        // v1.py — spectrum.astype(">u2"); sizing requires the negotiated n_disp_bins.
+        let message = try #require(BinaryMessage(data: binaryFrame(
+            .visualizerSpectrum, timestamp: 4, payload: [0x00, 0x01, 0x00, 0x02, 0x00, 0x03]
+        )))
+        let frame = try #require(VisualizerFrame(type: .spectrum, payload: message.data, spectrumBins: 3))
+        #expect(frame == .spectrum([1, 2, 3]))
+        // A mismatched bin count (or an unknown one) must reject, not mis-slice.
+        #expect(VisualizerFrame(type: .spectrum, payload: message.data, spectrumBins: 2) == nil)
+        #expect(VisualizerFrame(type: .spectrum, payload: message.data) == nil)
+    }
+
+    @Test
+    func binaryPeakAndPitchFrames_decode() throws {
+        // v1.py — peak: one u8 strength byte; pitch: struct.pack(">H", midi_q88) + confidence byte.
+        let peak = try #require(BinaryMessage(data: binaryFrame(.visualizerPeak, timestamp: 5, payload: [0xAB])))
+        #expect(VisualizerFrame(type: .peak, payload: peak.data) == .peak(strength: 0xAB))
+
+        let pitch = try #require(BinaryMessage(data: binaryFrame(.visualizerPitch, timestamp: 6, payload: [0x2D, 0x00, 0x80])))
+        #expect(VisualizerFrame(type: .pitch, payload: pitch.data) == .pitch(midiQ88: 0x2D00, confidence: 0x80))
+    }
+
+    @Test
+    func wrongLengthPayloads_rejectRatherThanMisdecode() {
+        #expect(VisualizerFrame(type: .loudness, payload: Data([0x01])) == nil)
+        #expect(VisualizerFrame(type: .beat, payload: Data()) == nil)
+        #expect(VisualizerFrame(type: .fPeak, payload: Data([0x01, 0x02])) == nil)
+        #expect(VisualizerFrame(type: .peak, payload: Data([0x01, 0x02])) == nil)
+        #expect(VisualizerFrame(type: .pitch, payload: Data([0x01, 0x02])) == nil)
+    }
+
+    @Test
+    func visualizerData_decodesItsPayloadThroughFrame() {
+        let data = VisualizerData(type: .loudness, data: Data([0x00, 0x7F]), localDisplayTime: 1_000)
+        #expect(data.frame() == .loudness(0x7F))
+    }
+}


### PR DESCRIPTION
### Summary

The visualizer role is currently a placeholder: `client/hello` encodes
`visualizer@v1_support` as an empty `{}`, the `stream/start` visualizer block decodes
to an empty struct, and only binary type 16 is recognized. Against aiosendspin 6.x
(Music Assistant 2.9.x) this is worse than "not implemented": **the server validates
the hello support object strictly and hard-rejects the entire `client/hello` when
`visualizer@v1` is advertised with an empty support object**, so turning the role on
breaks the whole connection during the handshake. (aiosendspin
`models/visualizer.py` `ClientHelloVisualizerSupport` requires non-empty `types`,
positive `buffer_capacity` and `rate_max`, and a `spectrum` object whenever
`"spectrum"` is in `types`.)

This PR implements the role end-to-end, following the existing artwork-role patterns:

- **`VisualizerConfiguration`** (public, `throws(ConfigurationError)`, mirrors
  `ArtworkConfiguration`): feature `types` (loudness / beat / f_peak / spectrum /
  peak / pitch), `spectrum` binning, `bufferCapacity`, `rateMax`. `SendspinClient`
  gains a `visualizerConfig:` parameter; advertising `.visualizerV1` without one
  throws `.visualizerRoleRequiresConfiguration`, so the rejected empty shape can no
  longer be sent (same pattern as `.playerRoleRequiresConfiguration`).
- **`client/hello`**: the internal `VisualizerSupport` wire struct now carries the
  validated real fields (`buffer_capacity`, `rate_max`, `types`, `spectrum`).
- **`stream/start`**: the negotiated visualizer announcement decodes into the public
  `StreamVisualizerConfig` (`types`, `rate_max`, `tracks_downbeats`, `spectrum`) and
  surfaces as `ClientEvent.visualizerStreamStarted(_:)` +
  `SendspinClient.currentVisualizerStream`. Decoding is tolerant: unknown feature
  strings are dropped and a malformed visualizer block cannot fail the whole
  `stream/start` (which would also kill the player section and silence audio).
- **Binary types 17–21** (beat, f_peak, spectrum, peak, pitch — aiosendspin
  `models/types.py` `BinaryMessageType`) are recognized and routed through the
  existing gate/clock-sync checks to the `visualizerData` stream; previously they
  were dropped as unknown type IDs at `BinaryMessage.init`. Type 16
  (`.visualizerData`) is renamed `.visualizerLoudness` per the per-feature ID
  allocation (internal enum, no public API break).
- **`VisualizerData`** now carries the feature `type` (without it, consumers of the
  multi-type stream can't tell a loudness frame from a beat frame — the type byte is
  stripped with the header) and offers `frame(spectrumBins:)` decoding into the new
  typed `VisualizerFrame` enum. Payload layouts follow the reference wire packing
  (`server/roles/visualizer/v1.py`, all big-endian: loudness u16; beat flags byte,
  bit 0 = downbeat; f_peak u16 freq + u16 amp; spectrum `n_disp_bins` × u16; peak
  u8; pitch u16 MIDI Q8.8 + u8 confidence). Wrong-length payloads reject rather
  than mis-decode; spectrum frames require the negotiated bin count for sizing.

One field-derived default worth calling out: **`rateMax` defaults to 30 Hz, not
60.** aiosendspin queues visualizer frames per-role for the entire audio write-ahead
window in a 4096-slot queue; at 5 feature types × 60 Hz (300 frames/s), the queue
overflows once write-ahead exceeds ~13.6 s — which a 2 MB player `buffer_capacity`
reaches on well-compressed FLAC — and the server then disconnects the client
("Role queue full for visualizer"). 30 Hz keeps a 5-type client safe past 27 s of
write-ahead. Found and verified against a live Music Assistant 2.9.8 /
aiosendspin 6.0.5 server.

### Commits

1. `feat(visualizer): implement the visualizer@v1 role per aiosendspin 6.0.5` —
   models + client wiring + CHANGELOG, plus mechanical updates of the three
   existing tests that referenced `.visualizerData` / the empty
   `StreamStartVisualizer`.
2. `test(visualizer): aiosendspin 6.0.5 conformance fixtures` — 15 golden-message
   tests hand-derived from the reference implementation
   (`Tests/SendspinKitTests/Models/VisualizerModelTests.swift`), including the
   regression guard that the encoded support object can never again be `{}`.

### Test evidence

On macOS (Apple Silicon, Swift 6.2.3 / Xcode 26.2 toolchain):

- `swift test` — **567 tests in 50 suites, all passing** (upstream main is 552;
  +15 new visualizer conformance tests; all pre-existing tests green, including the
  updated `FrameOrderingTests` visualizer gate/clock-sync ordering tests).
- `swiftlint lint --strict` — clean.
- `swiftformat --lint` (0.62.1) — all files touched by this PR are clean. (Note:
  0.62.1 flags ~15 *untouched* files on current `main` — e.g.
  `GroupUpdatePayload.encode`'s single-line `if` bodies — a rule-drift of the newer
  swiftformat vs. the version CI installed on the last main run. Not introduced
  here.)

### Compatibility

- No breaking public API changes: `visualizerConfig:` is a new defaulted init
  parameter; `VisualizerData` gains a field (it has no public initializer);
  `StreamRole` gains `.visualizer`; new public types are additive.
- Wire behavior change: clients that previously advertised `.visualizerV1` (and were
  rejected by 6.x servers at hello) now fail fast at `SendspinClient.init` unless
  they provide a configuration.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbdWgqSEcL2JhwBkwabRy3
